### PR TITLE
Add option to skip XtY precomputation

### DIFF
--- a/tests/testthat/test-cf_als_engine.R
+++ b/tests/testthat/test-cf_als_engine.R
@@ -25,3 +25,21 @@ test_that("cf_als_engine returns matrices with correct dimensions", {
   expect_equal(dim(res$h), c(dat$d, ncol(dat$Y)))
   expect_equal(dim(res$beta), c(dat$k, ncol(dat$Y)))
 })
+
+test_that("precompute_xty_flag FALSE reproduces TRUE", {
+  dat <- simple_cfals_data()
+  res_true <- cf_als_engine(dat$X_list, dat$Y,
+                            lambda_b = 0.1,
+                            lambda_h = 0.1,
+                            fullXtX_flag = FALSE,
+                            max_alt = 1,
+                            precompute_xty_flag = TRUE)
+  res_false <- cf_als_engine(dat$X_list, dat$Y,
+                             lambda_b = 0.1,
+                             lambda_h = 0.1,
+                             fullXtX_flag = FALSE,
+                             max_alt = 1,
+                             precompute_xty_flag = FALSE)
+  expect_equal(res_false$h, res_true$h)
+  expect_equal(res_false$beta, res_true$beta)
+})


### PR DESCRIPTION
## Summary
- add `precompute_xty_flag` parameter to `cf_als_engine`
- compute size of `XtY_list` and warn if it may exceed 2GB
- support on-the-fly crossproducts when not precomputing
- document the new argument and test equality of both code paths

## Testing
- `Rscript -e "library(testthat); test_dir('tests/testthat')"` *(fails: Rscript not found)*