### PR TITLE
Implement cfals engine refactor

### DIFF
--- a/R/cfals_wrapper.R
+++ b/R/cfals_wrapper.R
@@ -27,6 +27,8 @@
 #'   available from `hrf_basis`, it can be passed here.
 #' @param fullXtX Logical; if `TRUE` include cross condition terms in
 #'   the h update (where supported).
+#' @param precompute_xty_flag Logical; passed to `cf_als_engine` to control
+#'   precomputation of `XtY` matrices.
 #' @param max_alt Number of alternating updates after initialisation
 #'   when `method = "cf_als"`.
 #' @param ... Additional arguments passed to the underlying estimation engine.
@@ -62,6 +64,7 @@ fmrireg_cfals <- function(fmri_data_obj,
                          lambda_h = 1,
                          R_mat = NULL,
                          fullXtX = FALSE,
+                         precompute_xty_flag = TRUE,
                          max_alt = 1,
                          ...) {
 
@@ -105,10 +108,11 @@ fmrireg_cfals <- function(fmri_data_obj,
     cf_als = cf_als_engine(Xp, Yp,
                            lambda_b = lambda_b,
                            lambda_h = lambda_h,
+                           R_mat_eff = R_mat,
                            fullXtX_flag = fullXtX,
+                           precompute_xty_flag = precompute_xty_flag,
                            h_ref_shape_norm = design$h_ref_shape_norm,
-                           max_alt = max_alt,
-                           R_mat = R_mat, ...)
+                           max_alt = max_alt, ...)
   )
 
   rownames(fit$beta) <- cond_names

--- a/tests/testthat/test-cf_als_engine.R
+++ b/tests/testthat/test-cf_als_engine.R
@@ -20,8 +20,66 @@ test_that("cf_als_engine returns matrices with correct dimensions", {
   res <- cf_als_engine(dat$X_list, dat$Y,
                        lambda_b = 0.1,
                        lambda_h = 0.1,
+                       R_mat_eff = NULL,
                        fullXtX_flag = FALSE,
+                       precompute_xty_flag = TRUE,
                        max_alt = 1)
   expect_equal(dim(res$h), c(dat$d, ncol(dat$Y)))
   expect_equal(dim(res$beta), c(dat$k, ncol(dat$Y)))
+})
+
+simple_small_data <- function() {
+  set.seed(42)
+  n <- 20; d <- 2; k <- 2; v <- 2
+  h_true <- matrix(rnorm(d * v), d, v)
+  beta_true <- matrix(rnorm(k * v), k, v)
+  X_list <- lapply(seq_len(k), function(i) matrix(rnorm(n * d), n, d))
+  Y <- matrix(0, n, v)
+  for (c in seq_len(k)) {
+    Y <- Y + (X_list[[c]] %*% h_true) *
+      matrix(rep(beta_true[c, ], each = n), n, v)
+  }
+  list(X_list = X_list, Y = Y)
+}
+
+test_that("XtY strategies give identical results", {
+  dat <- simple_small_data()
+  Rm <- diag(2) * 1.5
+  res_pre <- cf_als_engine(dat$X_list, dat$Y,
+                           lambda_b = 0.1,
+                           lambda_h = 0.2,
+                           R_mat_eff = Rm,
+                           fullXtX_flag = FALSE,
+                           precompute_xty_flag = TRUE,
+                           max_alt = 1)
+  res_onfly <- cf_als_engine(dat$X_list, dat$Y,
+                             lambda_b = 0.1,
+                             lambda_h = 0.2,
+                             R_mat_eff = Rm,
+                             fullXtX_flag = FALSE,
+                             precompute_xty_flag = FALSE,
+                             max_alt = 1)
+  expect_equal(res_pre$h, res_onfly$h, tolerance = 1e-12)
+  expect_equal(res_pre$beta, res_onfly$beta, tolerance = 1e-12)
+})
+
+test_that("XtY strategies match with fullXtX", {
+  dat <- simple_small_data()
+  Rm <- diag(2) * 1.5
+  res_pre <- cf_als_engine(dat$X_list, dat$Y,
+                           lambda_b = 0.1,
+                           lambda_h = 0.2,
+                           R_mat_eff = Rm,
+                           fullXtX_flag = TRUE,
+                           precompute_xty_flag = TRUE,
+                           max_alt = 1)
+  res_onfly <- cf_als_engine(dat$X_list, dat$Y,
+                             lambda_b = 0.1,
+                             lambda_h = 0.2,
+                             R_mat_eff = Rm,
+                             fullXtX_flag = TRUE,
+                             precompute_xty_flag = FALSE,
+                             max_alt = 1)
+  expect_equal(res_pre$h, res_onfly$h, tolerance = 1e-12)
+  expect_equal(res_pre$beta, res_onfly$beta, tolerance = 1e-12)
 })

--- a/tests/testthat/test-cfals-wrapper.R
+++ b/tests/testthat/test-cfals-wrapper.R
@@ -88,7 +88,9 @@ test_that("cf_als_engine predictions match canonical GLM", {
   res <- cf_als_engine(dat$X_list, dat$Y,
                        lambda_b = 0,
                        lambda_h = 0,
+                       R_mat_eff = NULL,
                        fullXtX_flag = FALSE,
+                       precompute_xty_flag = TRUE,
                        max_alt = 1)
   n <- nrow(dat$Y)
   v <- ncol(dat$Y)


### PR DESCRIPTION
## Summary
- update cf_als_engine to accept custom penalty matrix and on-the-fly XtY
- propagate new arguments through wrapper
- add regression tests for precomputed and on-the-fly strategies

## Testing
- `R --version` *(fails: command not found)*