### PR TITLE
Fix integer overflow in size estimate

### DIFF
--- a/R/cf_als_engine.R
+++ b/R/cf_als_engine.R
@@ -75,7 +75,7 @@ cf_als_engine <- function(X_list_proj, Y_proj,
   XtX_list <- lapply(X_list_proj, crossprod)
 
 
-  size_est <- k * d * v * 8
+  size_est <- as.numeric(k) * d * v * 8
   if (precompute_xty_flag && size_est > 2e9) {
     message("Estimated size of XtY_list (", size_est,
             " bytes) is large; consider `precompute_xty_flag = FALSE`")

--- a/tests/testthat/test-cf_als_engine.R
+++ b/tests/testthat/test-cf_als_engine.R
@@ -102,3 +102,12 @@ test_that("precompute_xty_flag FALSE reproduces TRUE", {
   expect_equal(res_false$beta, res_true$beta)
 
 })
+
+test_that("size estimate uses numeric arithmetic", {
+  k <- .Machine$integer.max
+  d <- 2L
+  v <- 1L
+  size_est <- as.numeric(k) * d * v * 8
+  expect_true(is.finite(size_est))
+  expect_gt(size_est, 2e9)
+})


### PR DESCRIPTION
## Summary
- avoid integer overflow when estimating XtY list size
- test numeric arithmetic when size estimation uses large integers

## Testing
- `R CMD build .` *(fails: `bash: R: command not found`)*