### PR TITLE
Add input validation for h_ref_shape_norm length

### DIFF
--- a/R/cf_als_engine.R
+++ b/R/cf_als_engine.R
@@ -41,6 +41,8 @@ cf_als_engine <- function(X_list_proj, Y_proj,
   v <- ncol(Y_proj)
   d <- ncol(X_list_proj[[1]])
   k <- length(X_list_proj)
+  if (!is.null(h_ref_shape_norm) && length(h_ref_shape_norm) != d)
+    stop("`h_ref_shape_norm` must have length d")
   for (X in X_list_proj) {
     if (nrow(X) != n) stop("Design matrices must have same rows as Y_proj")
     if (ncol(X) != d) stop("All design matrices must have the same column count")

--- a/tests/testthat/test-cf_als_engine.R
+++ b/tests/testthat/test-cf_als_engine.R
@@ -102,3 +102,12 @@ test_that("precompute_xty_flag FALSE reproduces TRUE", {
   expect_equal(res_false$beta, res_true$beta)
 
 })
+
+test_that("h_ref_shape_norm length must equal d", {
+  dat <- simple_cfals_data()
+  bad_ref <- numeric(dat$d + 1)
+  expect_error(
+    cf_als_engine(dat$X_list, dat$Y, h_ref_shape_norm = bad_ref),
+    "`h_ref_shape_norm` must have length d"
+  )
+})


### PR DESCRIPTION
## Summary
- validate `h_ref_shape_norm` length in `cf_als_engine`
- test error when passed the wrong length

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*