### PR TITLE
Ensure symmetric penalty matrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ License: GPL-3
 Encoding: UTF-8
 RoxygenNote: 7.3.1 
 Imports:
-    fmrireg (>= 0.0.0.9000)
+    fmrireg (>= 0.0.0.9000),
+    Matrix
 Remotes:
     bbuchsbaum/fmrireg

--- a/R/cf_als_engine.R
+++ b/R/cf_als_engine.R
@@ -127,7 +127,7 @@ cf_als_engine <- function(X_list_proj, Y_proj,
     h_penalty_matrix <- if (is.null(R_mat_eff)) {
       diag(d)
     } else {
-      R_mat_eff
+      Matrix::forceSymmetric(R_mat_eff)
     }
 
     for (vx in seq_len(v)) {


### PR DESCRIPTION
## Summary
- symmetrize R_mat_eff when constructing h_penalty_matrix
- import the Matrix package for forceSymmetric

## Testing
- `R CMD check` *(fails: command not found)*