### PR TITLE
Implement HRFALS-V2.1-S3-T3 tests

### DIFF
--- a/tests/testthat/test-estimate_hrf_cfals.R
+++ b/tests/testthat/test-estimate_hrf_cfals.R
@@ -72,3 +72,53 @@ test_that("estimate_hrf_cfals matches direct ls_svd_1als", {
   expect_equal(wrap$beta_amps, direct$beta)
 })
 
+
+simulate_multiterm_data <- function(hrf_basis, noise_sd = 0.05) {
+  sf <- sampling_frame(blocklens = 60, TR = 1)
+  events <- data.frame(
+    onset = c(5, 15, 25, 35),
+    term1 = factor(c("A", "A", "B", "B")),
+    term2 = factor(c("C", "D", "C", "D")),
+    block = 1
+  )
+  emod <- event_model(onset ~ hrf(term1) + hrf(term2), data = events,
+                      block = ~ block, sampling_frame = sf)
+  reg_lists <- lapply(emod$terms, regressors.event_term,
+                      hrf = hrf_basis,
+                      sampling_frame = sf,
+                      summate = FALSE,
+                      drop.empty = TRUE)
+  regs <- unlist(reg_lists, recursive = FALSE)
+  sample_times <- samples(sf, global = TRUE)
+  X_list <- lapply(regs, function(r)
+    evaluate(r, sample_times, precision = sf$precision))
+  d <- nbasis(hrf_basis)
+  k <- length(X_list)
+  v <- 2
+  h_true <- matrix(rnorm(d * v), d, v)
+  beta_true <- matrix(rnorm(k * v), k, v)
+  Y <- matrix(0, nrow(sample_times), v)
+  for (c in seq_along(X_list)) {
+    Y <- Y + (X_list[[c]] %*% h_true) *
+      matrix(rep(beta_true[c, ], each = nrow(Y)), nrow(Y), v)
+  }
+  Y <- Y + matrix(rnorm(length(Y), sd = noise_sd), nrow(Y), v)
+  attr(Y, "sampling_frame") <- sf
+  list(Y = Y, event_model = emod)
+}
+
+
+test_that("estimate_hrf_cfals integrates across HRF bases and terms", {
+  bases <- list(HRF_SPMG3, hrfspline_generator(nbasis = 4))
+  for (b in bases) {
+    dat <- simulate_multiterm_data(b)
+    for (term in c("hrf(term1)", "hrf(term2)")) {
+      fit <- estimate_hrf_cfals(dat$Y, dat$event_model, term, b,
+                                lambda_b = 0.1, lambda_h = 0.1)
+      expect_s3_class(fit, "hrfals_fit")
+      expect_equal(nrow(fit$h_coeffs), nbasis(b))
+      expect_equal(fit$target_event_term_name, term)
+    }
+  }
+})
+


### PR DESCRIPTION
## Summary
- expand integration tests for `estimate_hrf_cfals`
- new helper generates multi-term event model for testing multiple HRF bases and terms

## Testing
- `R -q -e "print('test')"` *(fails: command not found)*