### PR TITLE
QA fix: add NA row handling

### DIFF
--- a/R/cfals_design_utils_hrfals.R
+++ b/R/cfals_design_utils_hrfals.R
@@ -42,7 +42,10 @@ convolve_timeseries_with_single_basis <- function(raw_timeseries,
 #' @param hrf_shape_duration_sec Duration for the HRF reconstruction grid.
 #' @param hrf_shape_sample_res_sec Sampling resolution for the HRF grid.
 #' @return List with projected design matrices, reconstruction info and
-#'   metadata for CFALS engines.
+#'   metadata for CFALS engines. Rows of `fmri_data_obj` containing `NA`
+#'   in any voxel are zeroed out along with the corresponding rows in the
+#'   design matrices and `confound_obj` (if provided). The indices of these
+#'   rows are returned as `bad_row_idx`.
 #' @export
 create_cfals_design <- function(fmri_data_obj,
                                event_model,
@@ -67,6 +70,9 @@ create_cfals_design <- function(fmri_data_obj,
   bad_row_idx <- which(apply(Y_raw, 1, function(r) any(is.na(r))))
   if (length(bad_row_idx) > 0) {
     Y_raw[bad_row_idx, ] <- 0
+    if (!is.null(confound_obj)) {
+      confound_obj[bad_row_idx, ] <- 0
+    }
   }
 
   # Get basis dimensions

--- a/R/estimate_hrf_cfals.R
+++ b/R/estimate_hrf_cfals.R
@@ -112,6 +112,7 @@ estimate_hrf_cfals <- function(fmri_data_obj,
              phi_recon_matrix = Phi,
              design_info = list(d = d, k = k, n = n, v = v, fullXtX = fullXtX),
              residuals = resids,
+             bad_row_idx = prep$bad_row_idx,
              recon_hrf = recon_hrf,
              gof = r2)
 }

--- a/R/hrfals_methods.R
+++ b/R/hrfals_methods.R
@@ -11,6 +11,8 @@
 #' @param fmrireg_hrf_basis_used HRF basis object supplied to the wrapper.
 #' @param design_info List with design metadata (d, k, n, v, fullXtX).
 #' @param residuals Residual matrix from the projected data fit.
+#' @param bad_row_idx Integer vector of time points that were zeroed due to NA
+#'   values.
 #' @param recon_hrf Matrix of reconstructed HRF shapes.
 #' @param gof Numeric vector of goodness-of-fit statistics per voxel.
 #' @return An object of class `hrfals_fit`.
@@ -18,6 +20,7 @@
 hrfals_fit <- function(h_coeffs, beta_amps, method, lambdas, call,
                        fmrireg_hrf_basis_used, target_event_term_name,
                        phi_recon_matrix, design_info, residuals,
+                       bad_row_idx = integer(0),
                        recon_hrf = NULL, gof = NULL) {
   out <- list(h_coeffs = h_coeffs,
               beta_amps = beta_amps,
@@ -29,6 +32,7 @@ hrfals_fit <- function(h_coeffs, beta_amps, method, lambdas, call,
               phi_recon_matrix = phi_recon_matrix,
               design_info = design_info,
               residuals = residuals,
+              bad_row_idx = bad_row_idx,
               reconstructed_hrfs = recon_hrf,
               gof_per_voxel = gof)
   class(out) <- c("hrfals_fit", "list")

--- a/tests/testthat/test-cfals_design_utils.R
+++ b/tests/testthat/test-cfals_design_utils.R
@@ -88,13 +88,33 @@ test_that("create_cfals_design zeroes NA rows", {
                       block = ~ block, sampling_frame = sf)
   Y <- matrix(rnorm(10 * 1), 10, 1)
   Y[3, ] <- NA
-  
+
   res <- create_cfals_design(Y, emod, HRF_SPMG3)
   
   expect_equal(res$bad_row_idx, 3)
   expect_true(all(res$Y_proj[3, ] == 0))
   for (Xc in res$X_list_proj) {
     expect_true(all(Xc[3, ] == 0))
+  }
+})
+
+test_that("create_cfals_design zeroes NA rows with confounds", {
+  sf <- sampling_frame(10, TR = 1)
+  events <- data.frame(onset = c(1, 5),
+                       condition = factor(c("A", "A")),
+                       block = 1)
+  emod <- event_model(onset ~ hrf(condition), data = events,
+                      block = ~ block, sampling_frame = sf)
+  Y <- matrix(rnorm(10 * 1), 10, 1)
+  Y[4, ] <- NA
+  Z <- matrix(rnorm(10), ncol = 1)
+
+  res <- create_cfals_design(Y, emod, HRF_SPMG3, Z)
+
+  expect_equal(res$bad_row_idx, 4)
+  expect_true(all(res$Y_proj[4, ] == 0))
+  for (Xc in res$X_list_proj) {
+    expect_true(all(Xc[4, ] == 0))
   }
 })
 

--- a/tests/testthat/test-estimate_hrf_cfals.R
+++ b/tests/testthat/test-estimate_hrf_cfals.R
@@ -49,6 +49,14 @@ test_that("estimate_hrf_cfals returns expected dimensions", {
   expect_true(is.matrix(fit$phi_recon_matrix))
 })
 
+test_that("estimate_hrf_cfals carries bad_row_idx", {
+  dat <- simulate_cfals_wrapper_data(HRF_SPMG3)
+  dat$Y[4, 1] <- NA
+  fit <- estimate_hrf_cfals(dat$Y, dat$event_model, "hrf(condition)", HRF_SPMG3,
+                            lambda_b = 0.1, lambda_h = 0.1)
+  expect_equal(fit$bad_row_idx, 4)
+})
+
 
 test_that("estimate_hrf_cfals matches direct ls_svd_1als", {
   dat <- simulate_cfals_wrapper_data(HRF_SPMG3)


### PR DESCRIPTION
## Summary
- zero out confound rows that match NA data rows
- track bad rows in the hrfals_fit object
- expose `bad_row_idx` from `estimate_hrf_cfals`
- test NA handling with and without confounds

## Testing
- `Rscript -e "library(testthat); test_dir('tests/testthat')"` *(fails: Rscript not found)*