### PR TITLE
Update identifiability in ALS engines

### DIFF
--- a/R/cf_als_engine.R
+++ b/R/cf_als_engine.R
@@ -13,7 +13,10 @@
 #' @param fullXtX_flag logical; if TRUE use cross-condition terms in h-update
 #' @param precompute_xty_flag logical; if TRUE precompute `XtY_list` otherwise
 #'   compute per voxel on-the-fly
-#' @param h_ref_shape_norm optional reference HRF shape for sign alignment
+#' @param Phi_recon_matrix Reconstruction matrix mapping coefficients to HRF
+#'   shape (p x d)
+#' @param h_ref_shape_canonical Canonical reference HRF shape of length p for
+#'   sign alignment
 #' @param max_alt number of alternating updates after initialization
 #' @param epsilon_svd tolerance for singular value screening
 #' @param epsilon_scale tolerance for scale in identifiability step
@@ -28,7 +31,8 @@ cf_als_engine <- function(X_list_proj, Y_proj,
                           R_mat_eff = NULL,
                           fullXtX_flag = FALSE,
                           precompute_xty_flag = TRUE,
-                          h_ref_shape_norm = NULL,
+                          Phi_recon_matrix,
+                          h_ref_shape_canonical,
                           max_alt = 1,
                           epsilon_svd = 1e-8,
                           epsilon_scale = 1e-8) {
@@ -37,8 +41,10 @@ cf_als_engine <- function(X_list_proj, Y_proj,
   v <- ncol(Y_proj)
   d <- ncol(X_list_proj[[1]])
   k <- length(X_list_proj)
-  if (!is.null(h_ref_shape_norm) && length(h_ref_shape_norm) != d)
-    stop("`h_ref_shape_norm` must have length d")
+  if (!is.matrix(Phi_recon_matrix) || ncol(Phi_recon_matrix) != d)
+    stop("`Phi_recon_matrix` must be a p x d matrix")
+  if (length(h_ref_shape_canonical) != nrow(Phi_recon_matrix))
+    stop("`h_ref_shape_canonical` must have length nrow(Phi_recon_matrix)")
   for (X in X_list_proj) {
     if (nrow(X) != n) stop("Design matrices must have same rows as Y_proj")
     if (ncol(X) != d) stop("All design matrices must have the same column count")
@@ -64,7 +70,8 @@ cf_als_engine <- function(X_list_proj, Y_proj,
 
   init <- ls_svd_engine(X_list_proj, Y_proj,
                         lambda_init = 0,
-                        h_ref_shape_norm = h_ref_shape_norm,
+                        Phi_recon_matrix = Phi_recon_matrix,
+                        h_ref_shape_canonical = h_ref_shape_canonical,
                         epsilon_svd = epsilon_svd,
                         epsilon_scale = epsilon_scale)
   h_current <- init$h
@@ -169,12 +176,11 @@ cf_als_engine <- function(X_list_proj, Y_proj,
     }
   }
 
-  scl <- apply(abs(h_current), 2, max)
+  H_shapes_iter <- Phi_recon_matrix %*% h_current
+  scl <- apply(abs(H_shapes_iter), 2, max)
   flip <- rep(1.0, v)
-  if (!is.null(h_ref_shape_norm)) {
-    align <- colSums(h_current * h_ref_shape_norm)
-    flip[align < 0 & scl > epsilon_scale] <- -1.0
-  }
+  align_scores <- colSums(H_shapes_iter * h_ref_shape_canonical)
+  flip[align_scores < 0 & scl > epsilon_scale] <- -1.0
   eff_scl <- pmax(scl, epsilon_scale)
   h_final <- sweep(h_current, 2, flip / eff_scl, "*")
   b_final <- sweep(b_current, 2, flip * eff_scl, "*")

--- a/R/estimate_hrf_cfals.R
+++ b/R/estimate_hrf_cfals.R
@@ -55,6 +55,7 @@ estimate_hrf_cfals <- function(fmri_data_obj,
   d <- prep$d_basis_dim
   k <- prep$k_conditions
   Phi <- prep$Phi_recon_matrix
+  h_ref_shape_canonical <- prep$h_ref_shape_canonical
   n <- prep$n_timepoints
   v <- prep$v_voxels
 
@@ -69,14 +70,16 @@ estimate_hrf_cfals <- function(fmri_data_obj,
   fit <- switch(method,
     ls_svd_only = ls_svd_engine(Xp, Yp,
                                 lambda_init = lambda_init,
-                                h_ref_shape_norm = NULL,
+                                Phi_recon_matrix = Phi,
+                                h_ref_shape_canonical = h_ref_shape_canonical,
                                 R_mat = R_eff),
     ls_svd_1als = ls_svd_1als_engine(Xp, Yp,
                                      lambda_init = lambda_init,
                                      lambda_b = lambda_b,
                                      lambda_h = lambda_h,
                                      fullXtX_flag = fullXtX,
-                                     h_ref_shape_norm = NULL,
+                                     Phi_recon_matrix = Phi,
+                                     h_ref_shape_canonical = h_ref_shape_canonical,
                                      R_mat = R_eff),
     cf_als = cf_als_engine(Xp, Yp,
                            lambda_b = lambda_b,
@@ -84,7 +87,8 @@ estimate_hrf_cfals <- function(fmri_data_obj,
                            R_mat_eff = R_eff,
                            fullXtX_flag = fullXtX,
                            precompute_xty_flag = precompute_xty_flag,
-                           h_ref_shape_norm = NULL,
+                           Phi_recon_matrix = Phi,
+                           h_ref_shape_canonical = h_ref_shape_canonical,
                            max_alt = max_alt)
   )
 

--- a/R/ls_svd_engine.R
+++ b/R/ls_svd_engine.R
@@ -7,7 +7,10 @@
 #' @param X_list_proj list of k design matrices (n x d each)
 #' @param Y_proj      numeric matrix of projected BOLD data (n x v)
 #' @param lambda_init ridge penalty for initial GLM solve
-#' @param h_ref_shape_norm optional reference HRF shape for sign alignment
+#' @param Phi_recon_matrix Reconstruction matrix mapping coefficients to HRF
+#'   shape (p x d)
+#' @param h_ref_shape_canonical Canonical reference HRF shape of length p for
+#'   sign alignment
 #' @param svd_backend currently ignored, placeholder for future backends
 #' @param epsilon_svd tolerance for singular value screening
 #' @param epsilon_scale tolerance for scale in identifiability step
@@ -17,7 +20,8 @@
 #' @keywords internal
 #' @noRd
 ls_svd_engine <- function(X_list_proj, Y_proj, lambda_init = 1,
-                          h_ref_shape_norm = NULL,
+                          Phi_recon_matrix,
+                          h_ref_shape_canonical,
                           svd_backend = c("base_R"),
                           epsilon_svd = 1e-8,
                           epsilon_scale = 1e-8,
@@ -32,8 +36,11 @@ ls_svd_engine <- function(X_list_proj, Y_proj, lambda_init = 1,
     if (nrow(X) != n) stop("Design matrices must have same rows as Y_proj")
     if (ncol(X) != d) stop("All design matrices must have the same column count")
   }
-  if (!is.null(h_ref_shape_norm) && length(h_ref_shape_norm) != d)
-    stop("`h_ref_shape_norm` must have length d")
+
+  if (!is.matrix(Phi_recon_matrix) || ncol(Phi_recon_matrix) != d)
+    stop("`Phi_recon_matrix` must be a p x d matrix")
+  if (length(h_ref_shape_canonical) != nrow(Phi_recon_matrix))
+    stop("`h_ref_shape_canonical` must have length nrow(Phi_recon_matrix)")
 
   if (!is.null(R_mat)) {
     if (!is.matrix(R_mat) || nrow(R_mat) != d || ncol(R_mat) != d) {
@@ -68,12 +75,11 @@ ls_svd_engine <- function(X_list_proj, Y_proj, lambda_init = 1,
     }
   }
 
-  scl <- apply(abs(H_out), 2, max)
+  H_shapes <- Phi_recon_matrix %*% H_out
+  scl <- apply(abs(H_shapes), 2, max)
   flip <- rep(1.0, v)
-  if (!is.null(h_ref_shape_norm)) {
-    align <- as.numeric(crossprod(h_ref_shape_norm, H_out))
-    flip[align < 0 & scl > epsilon_scale] <- -1.0
-  }
+  align <- colSums(H_shapes * h_ref_shape_canonical)
+  flip[align < 0 & scl > epsilon_scale] <- -1.0
   eff_scl <- pmax(scl, epsilon_scale)
   H_final <- sweep(H_out, 2, flip / eff_scl, "*")
   B_final <- sweep(B_out, 2, flip * eff_scl, "*")

--- a/tests/testthat/test-cfals-wrapper.R
+++ b/tests/testthat/test-cfals-wrapper.R
@@ -80,7 +80,9 @@ simple_cfals_data_noise <- function() {
   Xbig <- do.call(cbind, X_list)
   Y <- Xbig %*% as.vector(matrix(h_true, d, v) %*% t(beta_true))
   Y <- matrix(Y, n, v) + matrix(rnorm(n * v, sd = 0.01), n, v)
-  list(X_list = X_list, Y = Y, Xbig = Xbig)
+  phi <- diag(d)
+  href <- rep(1, nrow(phi))
+  list(X_list = X_list, Y = Y, Xbig = Xbig, Phi = phi, href = href)
 }
 
 test_that("cf_als_engine predictions match canonical GLM", {
@@ -91,6 +93,8 @@ test_that("cf_als_engine predictions match canonical GLM", {
                        R_mat_eff = NULL,
                        fullXtX_flag = FALSE,
                        precompute_xty_flag = TRUE,
+                       Phi_recon_matrix = dat$Phi,
+                       h_ref_shape_canonical = dat$href,
                        max_alt = 1)
   n <- nrow(dat$Y)
   v <- ncol(dat$Y)
@@ -108,12 +112,15 @@ test_that("fullXtX argument is forwarded through fmrireg_cfals", {
   dat <- simulate_cfals_wrapper_data(HRF_SPMG3)
   design <- create_fmri_design(dat$event_model, HRF_SPMG3)
   proj <- project_confounds(dat$Y, design$X_list, NULL)
+  href <- drop(reconstruction_matrix(HRF_SPMG1, dat$sframe))
+  href <- href / max(abs(href))
   direct <- ls_svd_1als_engine(proj$X_list, proj$Y,
                                lambda_init = 0,
                                lambda_b = 0.1,
                                lambda_h = 0.1,
                                fullXtX_flag = TRUE,
-                               h_ref_shape_norm = design$h_ref_shape_norm)
+                               Phi_recon_matrix = design$Phi,
+                               h_ref_shape_canonical = href)
   wrap <- fmrireg_cfals(dat$Y, dat$event_model, HRF_SPMG3,
                         method = "ls_svd_1als",
                         fullXtX = TRUE,

--- a/tests/testthat/test-estimate_hrf_cfals.R
+++ b/tests/testthat/test-estimate_hrf_cfals.R
@@ -58,7 +58,8 @@ test_that("estimate_hrf_cfals matches direct ls_svd_1als", {
                                lambda_b = 0.1,
                                lambda_h = 0.1,
                                fullXtX_flag = TRUE,
-                               h_ref_shape_norm = NULL,
+                               Phi_recon_matrix = prep$Phi_recon_matrix,
+                               h_ref_shape_canonical = prep$h_ref_shape_canonical,
                                R_mat = diag(prep$d_basis_dim))
   wrap <- estimate_hrf_cfals(dat$Y, dat$event_model, "hrf(condition)", HRF_SPMG3,
                              method = "ls_svd_1als",

--- a/tests/testthat/test-ls_svd_1als_engine.R
+++ b/tests/testthat/test-ls_svd_1als_engine.R
@@ -14,7 +14,10 @@ simple_ls_svd_data <- function() {
   Xbig <- do.call(cbind, X_list)
   Y <- Xbig %*% as.vector(matrix(h_true, d, v) %*% t(beta_true))
   Y <- matrix(Y, n, v)
-  list(X_list = X_list, Y = Y, d = d, k = k)
+  phi <- diag(d)
+  href <- rep(1, nrow(phi))
+  list(X_list = X_list, Y = Y, d = d, k = k,
+       Phi = phi, href = href)
 }
 
 test_that("ls_svd_1als_engine returns matrices with correct dimensions", {
@@ -22,7 +25,9 @@ test_that("ls_svd_1als_engine returns matrices with correct dimensions", {
   res <- ls_svd_1als_engine(dat$X_list, dat$Y,
                             lambda_init = 0,
                             lambda_b = 0.1,
-                            lambda_h = 0.1)
+                            lambda_h = 0.1,
+                            Phi_recon_matrix = dat$Phi,
+                            h_ref_shape_canonical = dat$href)
   expect_equal(dim(res$h), c(dat$d, ncol(dat$Y)))
   expect_equal(dim(res$beta), c(dat$k, ncol(dat$Y)))
   expect_equal(dim(res$h_ls_svd), c(dat$d, ncol(dat$Y)))
@@ -38,7 +43,9 @@ single_condition_data <- function() {
   h_true <- matrix(rnorm(d * v), d, v)
   b_true <- rnorm(v)
   Y <- (X %*% h_true) * matrix(rep(b_true, each = n), n, v)
-  list(X_list = list(X), Y = Y)
+  phi <- diag(d)
+  href <- rep(1, nrow(phi))
+  list(X_list = list(X), Y = Y, Phi = phi, href = href)
 }
 
 test_that("fullXtX_flag has no effect for single condition", {
@@ -47,12 +54,16 @@ test_that("fullXtX_flag has no effect for single condition", {
                                  lambda_init = 0,
                                  lambda_b = 0.1,
                                  lambda_h = 0.1,
-                                 fullXtX_flag = FALSE)
+                                 fullXtX_flag = FALSE,
+                                 Phi_recon_matrix = dat$Phi,
+                                 h_ref_shape_canonical = dat$href)
   res_full <- ls_svd_1als_engine(dat$X_list, dat$Y,
                                  lambda_init = 0,
                                  lambda_b = 0.1,
                                  lambda_h = 0.1,
-                                 fullXtX_flag = TRUE)
+                                 fullXtX_flag = TRUE,
+                                 Phi_recon_matrix = dat$Phi,
+                                 h_ref_shape_canonical = dat$href)
   expect_equal(res_diag$h, res_full$h)
   expect_equal(res_diag$beta, res_full$beta)
 })
@@ -70,7 +81,9 @@ correlated_data <- function() {
   Xbig <- do.call(cbind, X_list)
   Y <- Xbig %*% as.vector(matrix(h_true, d, v) %*% t(beta_true))
   Y <- matrix(Y, n, v)
-  list(X_list = X_list, Y = Y)
+  phi <- diag(d)
+  href <- rep(1, nrow(phi))
+  list(X_list = X_list, Y = Y, Phi = phi, href = href)
 }
 
 test_that("fullXtX_flag influences estimates when conditions correlate", {
@@ -79,11 +92,15 @@ test_that("fullXtX_flag influences estimates when conditions correlate", {
                                  lambda_init = 0,
                                  lambda_b = 0.1,
                                  lambda_h = 0.1,
-                                 fullXtX_flag = FALSE)
+                                 fullXtX_flag = FALSE,
+                                 Phi_recon_matrix = dat$Phi,
+                                 h_ref_shape_canonical = dat$href)
   res_full <- ls_svd_1als_engine(dat$X_list, dat$Y,
                                  lambda_init = 0,
                                  lambda_b = 0.1,
                                  lambda_h = 0.1,
-                                 fullXtX_flag = TRUE)
+                                 fullXtX_flag = TRUE,
+                                 Phi_recon_matrix = dat$Phi,
+                                 h_ref_shape_canonical = dat$href)
   expect_false(isTRUE(all.equal(res_diag$h, res_full$h)))
 })

--- a/tests/testthat/test-ls_svd_engine.R
+++ b/tests/testthat/test-ls_svd_engine.R
@@ -14,13 +14,19 @@ simple_ls_svd_data <- function() {
   Xbig <- do.call(cbind, X_list)
   Y <- Xbig %*% as.vector(matrix(h_true, d, v) %*% t(beta_true))
   Y <- matrix(Y, n, v)
-  list(X_list = X_list, Y = Y, d = d, k = k)
+  phi <- diag(d)
+  href <- rep(1, nrow(phi))
+  list(X_list = X_list, Y = Y, d = d, k = k,
+       Phi = phi, href = href)
 }
 
 
 test_that("ls_svd_engine returns matrices with correct dimensions", {
   dat <- simple_ls_svd_data()
-  res <- ls_svd_engine(dat$X_list, dat$Y, lambda_init = 0)
+  res <- ls_svd_engine(dat$X_list, dat$Y,
+                       lambda_init = 0,
+                       Phi_recon_matrix = dat$Phi,
+                       h_ref_shape_canonical = dat$href)
   expect_equal(dim(res$h), c(dat$d, ncol(dat$Y)))
   expect_equal(dim(res$beta), c(dat$k, ncol(dat$Y)))
   expect_equal(dim(res$Gamma_hat), c(dat$d * dat$k, ncol(dat$Y)))
@@ -29,7 +35,11 @@ test_that("ls_svd_engine returns matrices with correct dimensions", {
 test_that("ls_svd_engine supports custom penalty matrix", {
   dat <- simple_ls_svd_data()
   Rmat <- diag(dat$d) * 2
-  res <- ls_svd_engine(dat$X_list, dat$Y, lambda_init = 0.5, R_mat = Rmat)
+  res <- ls_svd_engine(dat$X_list, dat$Y,
+                       lambda_init = 0.5,
+                       Phi_recon_matrix = dat$Phi,
+                       h_ref_shape_canonical = dat$href,
+                       R_mat = Rmat)
   Xbig <- do.call(cbind, dat$X_list)
   XtX <- crossprod(Xbig)
   Xty <- crossprod(Xbig, dat$Y)


### PR DESCRIPTION
## Summary
- use canonical HRF shape for identifiability in `ls_svd_engine`, `ls_svd_1als_engine` and `cf_als_engine`
- pass `Phi_recon_matrix` and `h_ref_shape_canonical` through wrappers
- update unit tests for new engine arguments

## Testing
- `R CMD check` *(fails: `R` not found)*