### PR TITLE
Update engines and tests for canonical reconstruction args

### DIFF
--- a/tests/testthat/test-cf_als_engine.R
+++ b/tests/testthat/test-cf_als_engine.R
@@ -23,7 +23,9 @@ test_that("cf_als_engine returns matrices with correct dimensions", {
                        R_mat_eff = NULL,
                        fullXtX_flag = FALSE,
                        precompute_xty_flag = TRUE,
-                       max_alt = 1)
+                       max_alt = 1,
+                       Phi_recon_matrix = diag(dat$d),
+                       h_ref_shape_canonical = rep(1, dat$d))
   expect_equal(dim(res$h), c(dat$d, ncol(dat$Y)))
   expect_equal(dim(res$beta), c(dat$k, ncol(dat$Y)))
 })
@@ -52,14 +54,18 @@ test_that("XtY strategies give identical results", {
                            R_mat_eff = Rm,
                            fullXtX_flag = FALSE,
                            precompute_xty_flag = TRUE,
-                           max_alt = 1)
+                           max_alt = 1,
+                           Phi_recon_matrix = diag(2),
+                           h_ref_shape_canonical = rep(1, 2))
   res_onfly <- cf_als_engine(dat$X_list, dat$Y,
                              lambda_b = 0.1,
                              lambda_h = 0.2,
                              R_mat_eff = Rm,
                              fullXtX_flag = FALSE,
                              precompute_xty_flag = FALSE,
-                             max_alt = 1)
+                             max_alt = 1,
+                             Phi_recon_matrix = diag(2),
+                             h_ref_shape_canonical = rep(1, 2))
   expect_equal(res_pre$h, res_onfly$h, tolerance = 1e-12)
   expect_equal(res_pre$beta, res_onfly$beta, tolerance = 1e-12)
 })
@@ -73,14 +79,18 @@ test_that("XtY strategies match with fullXtX", {
                            R_mat_eff = Rm,
                            fullXtX_flag = TRUE,
                            precompute_xty_flag = TRUE,
-                           max_alt = 1)
+                           max_alt = 1,
+                           Phi_recon_matrix = diag(2),
+                           h_ref_shape_canonical = rep(1, 2))
   res_onfly <- cf_als_engine(dat$X_list, dat$Y,
                              lambda_b = 0.1,
                              lambda_h = 0.2,
                              R_mat_eff = Rm,
                              fullXtX_flag = TRUE,
                              precompute_xty_flag = FALSE,
-                             max_alt = 1)
+                             max_alt = 1,
+                             Phi_recon_matrix = diag(2),
+                             h_ref_shape_canonical = rep(1, 2))
   expect_equal(res_pre$h, res_onfly$h, tolerance = 1e-12)
   expect_equal(res_pre$beta, res_onfly$beta, tolerance = 1e-12)
 })
@@ -92,13 +102,17 @@ test_that("precompute_xty_flag FALSE reproduces TRUE", {
                             lambda_h = 0.1,
                             fullXtX_flag = FALSE,
                             max_alt = 1,
-                            precompute_xty_flag = TRUE)
+                            precompute_xty_flag = TRUE,
+                            Phi_recon_matrix = diag(dat$d),
+                            h_ref_shape_canonical = rep(1, dat$d))
   res_false <- cf_als_engine(dat$X_list, dat$Y,
                              lambda_b = 0.1,
                              lambda_h = 0.1,
                              fullXtX_flag = FALSE,
                              max_alt = 1,
-                             precompute_xty_flag = FALSE)
+                             precompute_xty_flag = FALSE,
+                             Phi_recon_matrix = diag(dat$d),
+                             h_ref_shape_canonical = rep(1, dat$d))
   expect_equal(res_false$h, res_true$h)
   expect_equal(res_false$beta, res_true$beta)
 })
@@ -108,7 +122,10 @@ test_that("h_ref_shape_norm length must equal d", {
   dat <- simple_cfals_data()
   bad_ref <- numeric(dat$d + 1)
   expect_error(
-    cf_als_engine(dat$X_list, dat$Y, h_ref_shape_norm = bad_ref),
+    cf_als_engine(dat$X_list, dat$Y,
+                  h_ref_shape_norm = bad_ref,
+                  Phi_recon_matrix = diag(dat$d),
+                  h_ref_shape_canonical = rep(1, dat$d)),
     "`h_ref_shape_norm` must have length d"
   )
 })

--- a/tests/testthat/test-cfals-wrapper.R
+++ b/tests/testthat/test-cfals-wrapper.R
@@ -41,11 +41,12 @@ test_that("fmrireg_hrf_cfals works across HRF bases", {
   bases <- list(HRF_SPMG3, hrfspline_generator(nbasis = 4))
   for (b in bases) {
     dat <- simulate_cfals_wrapper_data(b)
+    design <- create_cfals_design(dat$Y, dat$event_model, b)
     fit <- fmrireg_hrf_cfals(dat$Y, dat$event_model, b,
                              lam_beta = 0.1, lam_h = 0.1)
     expect_equal(dim(fit$h_coeffs), c(nbasis(b), ncol(dat$Y)))
     expect_equal(dim(fit$beta_amps), c(length(dat$X_list), ncol(dat$Y)))
-    recon <- reconstruction_matrix(b, dat$sframe) %*% fit$h_coeffs
+    recon <- design$Phi_recon_matrix %*% fit$h_coeffs
     expect_true(all(is.finite(recon)))
   }
 })
@@ -91,7 +92,9 @@ test_that("cf_als_engine predictions match canonical GLM", {
                        R_mat_eff = NULL,
                        fullXtX_flag = FALSE,
                        precompute_xty_flag = TRUE,
-                       max_alt = 1)
+                       max_alt = 1,
+                       Phi_recon_matrix = diag(ncol(dat$X_list[[1]])),
+                       h_ref_shape_canonical = rep(1, ncol(dat$X_list[[1]])))
   n <- nrow(dat$Y)
   v <- ncol(dat$Y)
   pred_cfals <- matrix(0, n, v)
@@ -113,7 +116,9 @@ test_that("fullXtX argument is forwarded through fmrireg_cfals", {
                                lambda_b = 0.1,
                                lambda_h = 0.1,
                                fullXtX_flag = TRUE,
-                               h_ref_shape_norm = design$h_ref_shape_norm)
+                               h_ref_shape_norm = design$h_ref_shape_norm,
+                               Phi_recon_matrix = reconstruction_matrix(HRF_SPMG3, dat$sframe),
+                               h_ref_shape_canonical = create_cfals_design(dat$Y, dat$event_model, HRF_SPMG3)$h_ref_shape_canonical)
   wrap <- fmrireg_cfals(dat$Y, dat$event_model, HRF_SPMG3,
                         method = "ls_svd_1als",
                         fullXtX = TRUE,

--- a/tests/testthat/test-estimate_hrf_cfals.R
+++ b/tests/testthat/test-estimate_hrf_cfals.R
@@ -59,6 +59,8 @@ test_that("estimate_hrf_cfals matches direct ls_svd_1als", {
                                lambda_h = 0.1,
                                fullXtX_flag = TRUE,
                                h_ref_shape_norm = NULL,
+                               Phi_recon_matrix = prep$Phi_recon_matrix,
+                               h_ref_shape_canonical = prep$h_ref_shape_canonical,
                                R_mat = diag(prep$d_basis_dim))
   wrap <- estimate_hrf_cfals(dat$Y, dat$event_model, "hrf(condition)", HRF_SPMG3,
                              method = "ls_svd_1als",

--- a/tests/testthat/test-ls_svd_1als_engine.R
+++ b/tests/testthat/test-ls_svd_1als_engine.R
@@ -22,7 +22,9 @@ test_that("ls_svd_1als_engine returns matrices with correct dimensions", {
   res <- ls_svd_1als_engine(dat$X_list, dat$Y,
                             lambda_init = 0,
                             lambda_b = 0.1,
-                            lambda_h = 0.1)
+                            lambda_h = 0.1,
+                            Phi_recon_matrix = diag(dat$d),
+                            h_ref_shape_canonical = rep(1, dat$d))
   expect_equal(dim(res$h), c(dat$d, ncol(dat$Y)))
   expect_equal(dim(res$beta), c(dat$k, ncol(dat$Y)))
   expect_equal(dim(res$h_ls_svd), c(dat$d, ncol(dat$Y)))
@@ -47,12 +49,16 @@ test_that("fullXtX_flag has no effect for single condition", {
                                  lambda_init = 0,
                                  lambda_b = 0.1,
                                  lambda_h = 0.1,
-                                 fullXtX_flag = FALSE)
+                                 fullXtX_flag = FALSE,
+                                 Phi_recon_matrix = diag(2),
+                                 h_ref_shape_canonical = rep(1, 2))
   res_full <- ls_svd_1als_engine(dat$X_list, dat$Y,
                                  lambda_init = 0,
                                  lambda_b = 0.1,
                                  lambda_h = 0.1,
-                                 fullXtX_flag = TRUE)
+                                 fullXtX_flag = TRUE,
+                                 Phi_recon_matrix = diag(2),
+                                 h_ref_shape_canonical = rep(1, 2))
   expect_equal(res_diag$h, res_full$h)
   expect_equal(res_diag$beta, res_full$beta)
 })
@@ -79,11 +85,15 @@ test_that("fullXtX_flag influences estimates when conditions correlate", {
                                  lambda_init = 0,
                                  lambda_b = 0.1,
                                  lambda_h = 0.1,
-                                 fullXtX_flag = FALSE)
+                                 fullXtX_flag = FALSE,
+                                 Phi_recon_matrix = diag(2),
+                                 h_ref_shape_canonical = rep(1, 2))
   res_full <- ls_svd_1als_engine(dat$X_list, dat$Y,
                                  lambda_init = 0,
                                  lambda_b = 0.1,
                                  lambda_h = 0.1,
-                                 fullXtX_flag = TRUE)
+                                 fullXtX_flag = TRUE,
+                                 Phi_recon_matrix = diag(2),
+                                 h_ref_shape_canonical = rep(1, 2))
   expect_false(isTRUE(all.equal(res_diag$h, res_full$h)))
 })


### PR DESCRIPTION
## Summary
- extend engine APIs with `Phi_recon_matrix` and `h_ref_shape_canonical`
- update identifiability steps to optionally use these arguments
- adjust unit tests to pass the new arguments when calling engines
- use `create_cfals_design` within wrapper tests for reconstruction checks

## Testing
- `R CMD check` *(fails: R not installed)*