### PR TITLE
Fix dynamic XtY recomputation

### DIFF
--- a/R/cf_als_engine.R
+++ b/R/cf_als_engine.R
@@ -157,6 +157,13 @@ cf_als_engine <- function(X_list_proj, Y_proj,
       b_vx <- b_current[, vx]
       lhs <- lambda_h * h_penalty_matrix
       rhs <- numeric(d)
+
+      if (!isTRUE(precompute_xty_flag)) {
+        XtY_cache <- vector("list", k)
+        for (l in seq_len(k)) {
+          XtY_cache[[l]] <- crossprod(X_list_proj[[l]], Y_proj[, vx])
+        }
+      }
       for (l in seq_len(k)) {
 
         XtY_l_vx <- if (isTRUE(precompute_xty_flag)) {

--- a/tests/testthat/test-cf_als_engine.R
+++ b/tests/testthat/test-cf_als_engine.R
@@ -162,6 +162,30 @@ test_that("precompute_xty_flag FALSE reproduces TRUE", {
   expect_equal(res_false$beta, res_true$beta)
 })
 
+test_that("precompute_xty_flag FALSE reproduces TRUE with multiple voxels", {
+  dat <- simple_small_data()
+  res_true <- cf_als_engine(dat$X_list, dat$Y,
+                            lambda_b = 0.1,
+                            lambda_h = 0.2,
+                            fullXtX_flag = FALSE,
+                            R_mat_eff = diag(2) * 1.5,
+                            max_alt = 1,
+                            precompute_xty_flag = TRUE,
+                            Phi_recon_matrix = dat$Phi,
+                            h_ref_shape_canonical = dat$href)
+  res_false <- cf_als_engine(dat$X_list, dat$Y,
+                             lambda_b = 0.1,
+                             lambda_h = 0.2,
+                             fullXtX_flag = FALSE,
+                             R_mat_eff = diag(2) * 1.5,
+                             max_alt = 1,
+                             precompute_xty_flag = FALSE,
+                             Phi_recon_matrix = dat$Phi,
+                             h_ref_shape_canonical = dat$href)
+  expect_equal(res_false$h, res_true$h)
+  expect_equal(res_false$beta, res_true$beta)
+})
+
 
 test_that("h_ref_shape_canonical length must equal p", {
   dat <- simple_cfals_data()


### PR DESCRIPTION
## Summary
- recompute `XtY_cache` inside the h‑update loop when on‑the‑fly calculation is requested
- add a unit test ensuring multiple voxels give the same result with and without precomputation

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: `bash: Rscript: command not found`)*