### PR TITLE
Fix penalty_R_mat_type option name

### DIFF
--- a/R/estimate_hrf_cfals.R
+++ b/R/estimate_hrf_cfals.R
@@ -14,7 +14,7 @@
 #' @param lambda_b Ridge penalty for the beta update.
 #' @param lambda_h Ridge penalty for the h update.
 #' @param penalty_R_mat_type How to construct the penalty matrix. One of
-#'   "identity", "basis", or "custom". If "custom", supply `R_mat`.
+#'   "identity", "basis_default", or "custom". If "custom", supply `R_mat`.
 #' @param R_mat Optional custom penalty matrix for the h update.
 #' @param fullXtX Logical; passed to the estimation engine.
 #' @param precompute_xty_flag Logical; passed to `cf_als_engine`.
@@ -32,7 +32,7 @@ estimate_hrf_cfals <- function(fmri_data_obj,
                                lambda_init = 1,
                                lambda_b = 10,
                                lambda_h = 1,
-                               penalty_R_mat_type = c("identity", "basis", "custom"),
+                               penalty_R_mat_type = c("identity", "basis_default", "custom"),
                                R_mat = NULL,
                                fullXtX = FALSE,
                                precompute_xty_flag = TRUE,
@@ -61,7 +61,7 @@ estimate_hrf_cfals <- function(fmri_data_obj,
 
   R_eff <- switch(penalty_R_mat_type,
                   identity = diag(d),
-                  basis = penalty_matrix(hrf_basis_for_cfals),
+                  basis_default = penalty_matrix(hrf_basis_for_cfals),
                   custom = {
                     if (is.null(R_mat)) stop("R_mat must be supplied for custom penalty")
                     R_mat

--- a/tests/testthat/test-estimate_hrf_cfals.R
+++ b/tests/testthat/test-estimate_hrf_cfals.R
@@ -90,7 +90,7 @@ test_that("estimate_hrf_cfals matches direct ls_svd_1als", {
   expect_equal(wrap$beta_amps, direct$beta)
 })
 
-test_that("penalty_R_mat_type 'basis' uses basis penalty matrix", {
+test_that("penalty_R_mat_type 'basis_default' uses basis penalty matrix", {
   dat <- simulate_cfals_wrapper_data(HRF_SPMG3)
   prep <- create_cfals_design(dat$Y, dat$event_model, HRF_SPMG3)
   Rb <- penalty_matrix(HRF_SPMG3)
@@ -107,7 +107,7 @@ test_that("penalty_R_mat_type 'basis' uses basis penalty matrix", {
                              lambda_b = 0.1,
                              lambda_h = 0.1,
                              fullXtX = TRUE,
-                             penalty_R_mat_type = "basis")
+                             penalty_R_mat_type = "basis_default")
   expect_equal(wrap$h_coeffs, direct$h)
   expect_equal(wrap$beta_amps, direct$beta)
 })


### PR DESCRIPTION
## Summary
- update documentation for `penalty_R_mat_type`
- use `basis_default` as the switch value
- adjust unit tests to match the new option

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: R not installed)*