### PR TITLE
Add penalty matrix option tests

### DIFF
--- a/tests/testthat/test-estimate_hrf_cfals.R
+++ b/tests/testthat/test-estimate_hrf_cfals.R
@@ -90,7 +90,7 @@ test_that("estimate_hrf_cfals matches direct ls_svd_1als", {
   expect_equal(wrap$beta_amps, direct$beta)
 })
 
-test_that("penalty_R_mat_type 'basis' uses basis penalty matrix", {
+test_that("penalty_R_mat_type 'basis'/'basis_default' uses basis penalty matrix", {
   dat <- simulate_cfals_wrapper_data(HRF_SPMG3)
   prep <- create_cfals_design(dat$Y, dat$event_model, HRF_SPMG3)
   Rb <- penalty_matrix(HRF_SPMG3)
@@ -101,15 +101,21 @@ test_that("penalty_R_mat_type 'basis' uses basis penalty matrix", {
                                fullXtX_flag = TRUE,
                                h_ref_shape_norm = NULL,
                                R_mat = Rb)
-  wrap <- estimate_hrf_cfals(dat$Y, dat$event_model, "hrf(condition)", HRF_SPMG3,
-                             method = "ls_svd_1als",
-                             lambda_init = 0,
-                             lambda_b = 0.1,
-                             lambda_h = 0.1,
-                             fullXtX = TRUE,
-                             penalty_R_mat_type = "basis")
-  expect_equal(wrap$h_coeffs, direct$h)
-  expect_equal(wrap$beta_amps, direct$beta)
+  allowed_opts <- eval(formals(estimate_hrf_cfals)$penalty_R_mat_type)
+  for (opt in c("basis", "basis_default")) {
+    if (!opt %in% allowed_opts) {
+      skip(paste("penalty_R_mat_type option", opt, "not supported"))
+    }
+    wrap <- estimate_hrf_cfals(dat$Y, dat$event_model, "hrf(condition)", HRF_SPMG3,
+                               method = "ls_svd_1als",
+                               lambda_init = 0,
+                               lambda_b = 0.1,
+                               lambda_h = 0.1,
+                               fullXtX = TRUE,
+                               penalty_R_mat_type = opt)
+    expect_equal(wrap$h_coeffs, direct$h)
+    expect_equal(wrap$beta_amps, direct$beta)
+  }
 })
 
 test_that("penalty_R_mat_type 'custom' uses provided matrix", {


### PR DESCRIPTION
## Summary
- expand estimate_hrf_cfals penalty matrix tests
  - cover `basis`/`basis_default` options
  - keep custom matrix check

## Testing
- `R -q -e "devtools::test()"` *(fails: R not installed)*