### PR TITLE
Standardize canonical HRF reference

### DIFF
--- a/R/cf_als_engine.R
+++ b/R/cf_als_engine.R
@@ -46,6 +46,8 @@ cf_als_engine <- function(X_list_proj, Y_proj,
     stop("`Phi_recon_matrix` must be a p x d matrix")
   if (length(h_ref_shape_canonical) != nrow(Phi_recon_matrix))
     stop("`h_ref_shape_canonical` must have length nrow(Phi_recon_matrix)")
+  if (abs(max(abs(h_ref_shape_canonical)) - 1) > 1e-6)
+    stop("`h_ref_shape_canonical` must be normalised to have max abs of 1")
   for (X in X_list_proj) {
     if (nrow(X) != n) stop("Design matrices must have same rows as Y_proj")
     if (ncol(X) != d) stop("All design matrices must have the same column count")

--- a/R/ls_svd_1als_engine.R
+++ b/R/ls_svd_1als_engine.R
@@ -42,6 +42,8 @@ ls_svd_1als_engine <- function(X_list_proj, Y_proj,
     stop("`Phi_recon_matrix` must be a p x d matrix")
   if (length(h_ref_shape_canonical) != nrow(Phi_recon_matrix))
     stop("`h_ref_shape_canonical` must have length nrow(Phi_recon_matrix)")
+  if (abs(max(abs(h_ref_shape_canonical)) - 1) > 1e-6)
+    stop("`h_ref_shape_canonical` must be normalised to have max abs of 1")
 
   if (!is.null(R_mat)) {
     if (!is.matrix(R_mat) || nrow(R_mat) != d || ncol(R_mat) != d) {

--- a/R/ls_svd_engine.R
+++ b/R/ls_svd_engine.R
@@ -41,6 +41,8 @@ ls_svd_engine <- function(X_list_proj, Y_proj, lambda_init = 1,
     stop("`Phi_recon_matrix` must be a p x d matrix")
   if (length(h_ref_shape_canonical) != nrow(Phi_recon_matrix))
     stop("`h_ref_shape_canonical` must have length nrow(Phi_recon_matrix)")
+  if (abs(max(abs(h_ref_shape_canonical)) - 1) > 1e-6)
+    stop("`h_ref_shape_canonical` must be normalised to have max abs of 1")
 
   if (!is.null(R_mat)) {
     if (!is.matrix(R_mat) || nrow(R_mat) != d || ncol(R_mat) != d) {

--- a/tests/testthat/test-cf_als_engine.R
+++ b/tests/testthat/test-cf_als_engine.R
@@ -133,6 +133,17 @@ test_that("h_ref_shape_canonical length must equal p", {
     "`h_ref_shape_canonical` must have length"
   )
 })
+
+test_that("h_ref_shape_canonical must be normalised", {
+  dat <- simple_cfals_data()
+  bad_ref <- dat$href * 2
+  expect_error(
+    cf_als_engine(dat$X_list, dat$Y,
+                  Phi_recon_matrix = dat$Phi,
+                  h_ref_shape_canonical = bad_ref),
+    "must be normalised"
+  )
+})
           
 test_that("size estimate uses numeric arithmetic", {
   k <- .Machine$integer.max

--- a/tests/testthat/test-cfals_design_utils.R
+++ b/tests/testthat/test-cfals_design_utils.R
@@ -45,6 +45,8 @@ test_that("create_fmri_design returns expected structure", {
   expect_equal(des$k, length(des$X_list))
   expect_true(is.matrix(des$Phi))
   expect_true(is.numeric(des$h_ref_shape_norm))
+  expect_equal(length(des$h_ref_shape_norm), nrow(des$Phi))
+  expect_equal(max(abs(des$h_ref_shape_norm)), 1)
 })
 
 test_that("create_cfals_design returns expected structure", {
@@ -69,6 +71,8 @@ test_that("create_cfals_design returns expected structure", {
   expect_length(res$X_list_proj, 2)
   expect_true(is.matrix(res$Phi_recon_matrix))
   expect_true(is.numeric(res$h_ref_shape_canonical))
+  expect_equal(length(res$h_ref_shape_canonical), nrow(res$Phi_recon_matrix))
+  expect_equal(max(abs(res$h_ref_shape_canonical)), 1)
   expect_equal(length(res$condition_names), 2)
   
   # Check compatibility fields

--- a/tests/testthat/test-ls_svd_1als_engine.R
+++ b/tests/testthat/test-ls_svd_1als_engine.R
@@ -104,3 +104,17 @@ test_that("fullXtX_flag influences estimates when conditions correlate", {
                                  h_ref_shape_canonical = dat$href)
   expect_false(isTRUE(all.equal(res_diag$h, res_full$h)))
 })
+
+test_that("ls_svd_1als_engine requires normalised h_ref", {
+  dat <- simple_ls_svd_data()
+  bad_ref <- dat$href * 2
+  expect_error(
+    ls_svd_1als_engine(dat$X_list, dat$Y,
+                       lambda_init = 0,
+                       lambda_b = 0.1,
+                       lambda_h = 0.1,
+                       Phi_recon_matrix = dat$Phi,
+                       h_ref_shape_canonical = bad_ref),
+    "must be normalised"
+  )
+})

--- a/tests/testthat/test-ls_svd_engine.R
+++ b/tests/testthat/test-ls_svd_engine.R
@@ -47,3 +47,15 @@ test_that("ls_svd_engine supports custom penalty matrix", {
   Gamma_manual <- solve(XtX + 0.5 * bigR, Xty)
   expect_equal(res$Gamma_hat, Gamma_manual)
 })
+
+test_that("ls_svd_engine requires normalised h_ref", {
+  dat <- simple_ls_svd_data()
+  bad_ref <- dat$href * 2
+  expect_error(
+    ls_svd_engine(dat$X_list, dat$Y,
+                  lambda_init = 0,
+                  Phi_recon_matrix = dat$Phi,
+                  h_ref_shape_canonical = bad_ref),
+    "must be normalised"
+  )
+})


### PR DESCRIPTION
## Summary
- generate canonical reference HRF in `create_fmri_design()` using SPMG1 and check its length
- validate normalisation of `h_ref_shape_canonical` in all engines
- unit tests now verify reference HRF length and scale for design creation and engines

## Testing
- `R CMD build` *(fails: `bash: R: command not found`)*