### PR TITLE
Improve fullXtX docs and unify cholSolve

### DIFF
--- a/R/cfals_wrapper.R
+++ b/R/cfals_wrapper.R
@@ -25,8 +25,13 @@
 #'   If `NULL` (default), an identity matrix is used, corresponding to a simple
 #'   ridge penalty. If a basis-specific penalty (e.g., for smoothing) is
 #'   available from `hrf_basis`, it can be passed here.
-#' @param fullXtX Logical; if `TRUE` include cross condition terms in
-#'   the h update (where supported).
+#' @param fullXtX Logical. If `TRUE`, the h-update step uses the full
+#'   Gramian matrix \eqn{(\sum_l \beta_l X_l)^\top (\sum_m \beta_m X_m)},
+#'   including cross-condition terms \eqn{\beta_l \beta_m X_l^\top X_m}.
+#'   If `FALSE` (default), cross-condition terms are omitted and the
+#'   Gramian is approximated by \eqn{\sum_l \beta_l^2 X_l^\top X_l}.
+#'   In both cases a single shared HRF coefficient vector is estimated
+#'   per voxel.
 #' @param precompute_xty_flag Logical; passed to `cf_als_engine` to control
 #'   precomputation of `XtY` matrices.
 #' @param max_alt Number of alternating updates after initialisation
@@ -40,9 +45,10 @@
 #' ALS refinement step, or the iterative \code{"cf_als"} engine.  The
 #' ridge penalties \code{lambda_init}, \code{lambda_b} and
 #' \code{lambda_h} control regularisation of the initial solve, the
-#' beta-update and the h-update respectively.  Setting
-#' \code{fullXtX = TRUE} includes cross-condition terms in the h-update
-#' (when supported by the chosen engine).  R\eqn{^2} is computed on the
+#' beta-update and the h-update respectively.  When
+#' \code{fullXtX = TRUE} the h-update uses the full cross-condition
+#' Gramian; otherwise an approximation ignoring off-diagonal terms is
+#' used. R\eqn{^2} is computed on the
 #' data after confound projection.
 #'
 #' @examples
@@ -193,12 +199,13 @@ fmrireg_cfals <- function(fmri_data_obj,
 #'   If `NULL` (default), an identity matrix is used, corresponding to a simple
 #'   ridge penalty. If a basis-specific penalty (e.g., for smoothing) is
 #'   available from `hrf_basis`, it can be passed here.
-#' @param fullXtX Logical. If `TRUE`, include cross-condition terms in the
-#'   h-update, meaning the design matrices for all conditions are used jointly
-#'   when estimating the HRF coefficients. If `FALSE` (default), the HRF
-#'   coefficients are estimated independently for each condition (though the
-#'   same HRF shape `h` is assumed across conditions if not voxel-wise).
-#'   The proposal indicates `fullXtX` is for the h-update.
+#' @param fullXtX Logical. If `TRUE`, the h-update step uses the full
+#'   Gramian matrix \eqn{(\sum_l \beta_l X_l)^\top (\sum_m \beta_m X_m)},
+#'   including cross-condition terms \eqn{\beta_l \beta_m X_l^\top X_m}.
+#'   If `FALSE` (default), cross-condition terms are omitted and the
+#'   Gramian is approximated by \eqn{\sum_l \beta_l^2 X_l^\top X_l}. In
+#'   both cases a single shared HRF coefficient vector is estimated per
+#'   voxel.
 #' @param max_alt Integer. The maximum number of alternations between the beta
 #'   and h updates. The proposal notes that empirically one alternation
 #'   (`max_alt = 1`) after SVD initialization is often sufficient.

--- a/R/estimate_hrf_cfals.R
+++ b/R/estimate_hrf_cfals.R
@@ -16,7 +16,12 @@
 #' @param penalty_R_mat_type How to construct the penalty matrix. One of
 #'   "identity", "basis_default", or "custom". If "custom", supply `R_mat`.
 #' @param R_mat Optional custom penalty matrix for the h update.
-#' @param fullXtX Logical; passed to the estimation engine.
+#' @param fullXtX Logical. If `TRUE`, the h-update step uses the full
+#'   Gramian matrix \eqn{(\sum_l \beta_l X_l)^\top (\sum_m \beta_m X_m)}
+#'   with cross-condition terms. If `FALSE` (default), the Gramian is
+#'   approximated by omitting cross-condition terms,
+#'   \eqn{\sum_l \beta_l^2 X_l^\top X_l}. A single shared HRF
+#'   coefficient vector is still estimated per voxel.
 #' @param precompute_xty_flag Logical; passed to `cf_als_engine`.
 #' @param max_alt Number of alternating updates for `cf_als`.
 #' @param hrf_shape_duration Duration in seconds for reconstructed HRF grid.

--- a/R/ls_svd_engine.R
+++ b/R/ls_svd_engine.R
@@ -42,17 +42,12 @@ ls_svd_engine <- function(X_list_proj, Y_proj, lambda_init = 1,
   if (abs(max(abs(h_ref_shape_canonical)) - 1) > 1e-6)
     stop("`h_ref_shape_canonical` must be normalised to have max abs of 1")
 
-  cholSolve <- function(M, B, eps = max(epsilon_svd, epsilon_scale)) {
-    L <- tryCatch(chol(M),
-                  error = function(e) chol(M + eps * diag(nrow(M))))
-    backsolve(L, forwardsolve(t(L), B))
-  }
 
   Xbig <- do.call(cbind, X_list_proj)
   XtX  <- crossprod(Xbig)
   Xty  <- crossprod(Xbig, Y_proj)
   XtX_ridge <- XtX + lambda_init * diag(d * k)
-  Gamma_hat <- cholSolve(XtX_ridge, Xty)
+  Gamma_hat <- cholSolve(XtX_ridge, Xty, eps = max(epsilon_svd, epsilon_scale))
 
   H_out <- matrix(0.0, d, v)
   B_out <- matrix(0.0, k, v)

--- a/R/utils_matrix.R
+++ b/R/utils_matrix.R
@@ -1,0 +1,21 @@
+#' Solve linear systems via Cholesky with ridge fallback
+#'
+#' Attempts to solve \code{M %*% x = B} using Cholesky factorisation. If
+#' \code{chol()} fails or the resulting factor has a very small diagonal,
+#' a ridge of size \code{eps} is added to the diagonal of \code{M} before
+#' solving.
+#'
+#' @param M Symmetric positive definite matrix.
+#' @param B Right-hand side matrix or vector.
+#' @param eps Ridge factor added if \code{M} is ill-conditioned.
+#' @return Solution with the same shape as \code{B}.
+#' @keywords internal
+#' @noRd
+cholSolve <- function(M, B, eps = 1e-8) {
+  ok <- TRUE
+  L <- tryCatch(chol(M), error = function(e) { ok <<- FALSE ; NULL })
+  if (!ok || (is.null(L) || min(diag(L)) < eps)) {
+    L <- chol(M + eps * diag(nrow(M)))
+  }
+  backsolve(L, forwardsolve(t(L), B))
+}

--- a/tests/testthat/test-utils_matrix.R
+++ b/tests/testthat/test-utils_matrix.R
@@ -1,0 +1,16 @@
+library(testthat)
+context("cholSolve utility")
+
+set.seed(1)
+
+M_small <- diag(c(1, 1e-12, 2))
+b <- rnorm(3)
+
+# when chol succeeds but diag element is below eps
+res <- cholSolve(M_small, b, eps = 1e-5)
+expect_equal(res, solve(M_small + 1e-5 * diag(3), b))
+
+# when chol fails (rank deficient)
+M_rankdef <- diag(c(1, 0, 2))
+res2 <- cholSolve(M_rankdef, b, eps = 1e-5)
+expect_equal(res2, solve(M_rankdef + 1e-5 * diag(3), b))


### PR DESCRIPTION
## Summary
- clarify `fullXtX` parameter documentation in wrappers and engines
- share a robust `cholSolve` helper in `utils_matrix.R`
- update engines to use the shared solver
- add unit test for `cholSolve`

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*