### PR TITLE
Implement memory-aware LSS

### DIFF
--- a/R/lss_mode_a.R
+++ b/R/lss_mode_a.R
@@ -14,10 +14,20 @@
 #'   pseudoinverse of \code{A}.
 #' @param woodbury_thresh Threshold for switching from Woodbury to
 #'   QR-based residualisation. See \code{auto_residualize}.
+#' @param chunk_size Optional chunk size (number of trials) used to
+#'   process \code{C} in blocks. Set automatically when
+#'   \code{mem_limit} is supplied.
+#' @param progress Logical; display a progress bar when processing in
+#'   chunks.
+#' @param mem_limit Optional memory limit in megabytes for automatic
+#'   chunking.
 #' @return A numeric matrix of trial coefficients (T x v).
 #' @export
 lss_mode_a <- function(Y, A, C, p_vec, lambda_ridge = 0,
-                       woodbury_thresh = 50) {
+                       woodbury_thresh = 50,
+                       chunk_size = NULL,
+                       progress = FALSE,
+                       mem_limit = NULL) {
   stopifnot(is.matrix(Y), is.matrix(A), is.matrix(C))
   n <- nrow(Y)
   if (nrow(A) != n || nrow(C) != n)
@@ -28,20 +38,50 @@ lss_mode_a <- function(Y, A, C, p_vec, lambda_ridge = 0,
   m <- ncol(A)
   Tt <- ncol(C)
 
-  V <- auto_residualize(C, A, lambda_ridge,
-                        woodbury_thresh = woodbury_thresh)
+  if (!is.null(mem_limit) && is.null(chunk_size)) {
+    bytes_limit <- mem_limit * 1024^2
+    max_chunk <- floor(bytes_limit / (8 * n))
+    if (max_chunk > 0 && max_chunk < Tt)
+      chunk_size <- max_chunk
+  }
 
-  pc_row <- drop(crossprod(p_vec, C))     # length T
-  cv_row <- colSums(V * V)
-  alpha_row <- numeric(Tt)
-  nz <- cv_row > 0
-  alpha_row[nz] <- (1 - pc_row[nz]) / cv_row[nz]
-  alpha_row[!nz] <- 0
+  if (is.null(chunk_size) || chunk_size >= Tt) {
+    V <- auto_residualize(C, A, lambda_ridge,
+                          woodbury_thresh = woodbury_thresh)
+    pc_row <- drop(crossprod(p_vec, C))     # length T
+    cv_row <- colSums(V * V)
+    alpha_row <- numeric(Tt)
+    nz <- cv_row > 0
+    alpha_row[nz] <- (1 - pc_row[nz]) / cv_row[nz]
+    alpha_row[!nz] <- 0
+    S <- sweep(V, 2, alpha_row, "*")
+    S <- S + p_vec
+    B <- crossprod(S, Y)    # T x v
+  } else {
+    idx_list <- split(seq_len(Tt), ceiling(seq_len(Tt) / chunk_size))
+    B <- matrix(0, Tt, ncol(Y))
+    if (progress)
+      pb <- txtProgressBar(min = 0, max = length(idx_list), style = 3)
+    i <- 0
+    for (idx in idx_list) {
+      i <- i + 1
+      C_chunk <- C[, idx, drop = FALSE]
+      V_chunk <- auto_residualize(C_chunk, A, lambda_ridge,
+                                  woodbury_thresh = woodbury_thresh)
+      pc_row <- drop(crossprod(p_vec, C_chunk))
+      cv_row <- colSums(V_chunk * V_chunk)
+      alpha_row <- numeric(length(idx))
+      nz <- cv_row > 0
+      alpha_row[nz] <- (1 - pc_row[nz]) / cv_row[nz]
+      alpha_row[!nz] <- 0
+      S_chunk <- sweep(V_chunk, 2, alpha_row, "*")
+      S_chunk <- S_chunk + p_vec
+      B[idx, ] <- crossprod(S_chunk, Y)
+      if (progress) setTxtProgressBar(pb, i)
+    }
+    if (progress) close(pb)
+  }
 
-  S <- sweep(V, 2, alpha_row, "*")
-  S <- S + p_vec
-
-  B <- crossprod(S, Y)    # T x v
   dimnames(B) <- list(colnames(C), colnames(Y))
   B
 }

--- a/R/lss_mode_b.R
+++ b/R/lss_mode_b.R
@@ -16,11 +16,21 @@
 #'   pseudoinverse of \code{A}.
 #' @param woodbury_thresh Threshold for switching from Woodbury to
 #'   QR-based residualisation. See \code{auto_residualize}.
+#' @param chunk_size Optional chunk size (number of trials) used to
+#'   process per voxel when memory limits are a concern. Set
+#'   automatically when \code{mem_limit} is supplied.
+#' @param progress Logical; display a progress bar over voxels when
+#'   \code{TRUE}.
+#' @param mem_limit Optional memory limit in megabytes for automatic
+#'   chunking.
 #' @return Numeric matrix of trial coefficients (T x v).
 #' @export
 lss_mode_b <- function(Y, A, X_onset_list, H_allvoxels, p_vec,
                        lambda_ridge = 0,
-                       woodbury_thresh = 50) {
+                       woodbury_thresh = 50,
+                       chunk_size = NULL,
+                       progress = FALSE,
+                       mem_limit = NULL) {
   stopifnot(is.matrix(Y), is.matrix(A), is.list(X_onset_list),
             is.matrix(H_allvoxels))
   n <- nrow(Y)
@@ -43,24 +53,57 @@ lss_mode_b <- function(Y, A, X_onset_list, H_allvoxels, p_vec,
     trial_names <- paste0("T", seq_len(Tt))
   B <- matrix(0, Tt, v)
 
+  if (!is.null(mem_limit) && is.null(chunk_size)) {
+    bytes_limit <- mem_limit * 1024^2
+    max_chunk <- floor(bytes_limit / (8 * n))
+    if (max_chunk > 0 && max_chunk < Tt)
+      chunk_size <- max_chunk
+  }
+
+  if (progress)
+    pb <- txtProgressBar(min = 0, max = v, style = 3)
+
   for (vx in seq_len(v)) {
     h_v <- H_allvoxels[, vx]
     C_v <- matrix(0, n, Tt)
     for (t in seq_len(Tt)) {
       C_v[, t] <- X_onset_list[[t]] %*% h_v
     }
-    V_v <- auto_residualize(C_v, A, lambda_ridge,
-                            woodbury_thresh = woodbury_thresh)
-    pc_row <- drop(crossprod(p_vec, C_v))
-    cv_row <- colSums(V_v * V_v)
-    alpha_row <- numeric(Tt)
-    nz <- cv_row > 0
-    alpha_row[nz] <- (1 - pc_row[nz]) / cv_row[nz]
-    alpha_row[!nz] <- 0
-    S_v <- sweep(V_v, 2, alpha_row, "*")
-    S_v <- S_v + p_vec
-    B[, vx] <- crossprod(S_v, Y[, vx])
+
+    if (is.null(chunk_size) || chunk_size >= Tt) {
+      V_v <- auto_residualize(C_v, A, lambda_ridge,
+                              woodbury_thresh = woodbury_thresh)
+      pc_row <- drop(crossprod(p_vec, C_v))
+      cv_row <- colSums(V_v * V_v)
+      alpha_row <- numeric(Tt)
+      nz <- cv_row > 0
+      alpha_row[nz] <- (1 - pc_row[nz]) / cv_row[nz]
+      alpha_row[!nz] <- 0
+      S_v <- sweep(V_v, 2, alpha_row, "*")
+      S_v <- S_v + p_vec
+      B[, vx] <- crossprod(S_v, Y[, vx])
+    } else {
+      idx_list <- split(seq_len(Tt), ceiling(seq_len(Tt) / chunk_size))
+      res_col <- numeric(Tt)
+      for (idx in idx_list) {
+        C_chunk <- C_v[, idx, drop = FALSE]
+        V_chunk <- auto_residualize(C_chunk, A, lambda_ridge,
+                                    woodbury_thresh = woodbury_thresh)
+        pc_row <- drop(crossprod(p_vec, C_chunk))
+        cv_row <- colSums(V_chunk * V_chunk)
+        alpha_row <- numeric(length(idx))
+        nz <- cv_row > 0
+        alpha_row[nz] <- (1 - pc_row[nz]) / cv_row[nz]
+        alpha_row[!nz] <- 0
+        S_chunk <- sweep(V_chunk, 2, alpha_row, "*")
+        S_chunk <- S_chunk + p_vec
+        res_col[idx] <- crossprod(S_chunk, Y[, vx])
+      }
+      B[, vx] <- res_col
+    }
+    if (progress) setTxtProgressBar(pb, vx)
   }
+  if (progress) close(pb)
   dimnames(B) <- list(trial_names, colnames(Y))
   B
 }


### PR DESCRIPTION
## Summary
- extend `lss_mode_a()` with optional chunking and progress bar
- extend `lss_mode_b()` similarly

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: `bash: R: command not found`)*