### PR TITLE
Move voxel Laplacian builder to C++

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -31,3 +31,13 @@ lss_check_conditioning <- function(A, lambda_ridge = 0.0) {
     .Call(`_hrfals_lss_check_conditioning`, A, lambda_ridge)
 }
 
+#' Build voxel Laplacian using C++
+#'
+#' @param volume 3D mask volume
+#' @param connectivity neighbourhood definition
+#' @keywords internal
+#' @export
+build_voxel_laplacian_cpp <- function(volume, connectivity = 6L) {
+    .Call(`_hrfals_build_voxel_laplacian_cpp`, volume, connectivity)
+}
+

--- a/R/utils_spatial.R
+++ b/R/utils_spatial.R
@@ -12,63 +12,7 @@
 #'   numeric degree vector `degree`.
 #' @export
 build_voxel_laplacian <- function(volume, connectivity = 6) {
-  vol <- as.array(volume)
-  if (length(dim(vol)) != 3) {
-    stop("'volume' must be 3D")
-  }
-  mask <- vol != 0
-  dims <- dim(mask)
-  coords <- which(mask, arr.ind = TRUE)
-  v <- nrow(coords)
-  if (v == 0) {
-    stop("mask contains no voxels")
-  }
-  index_map <- array(0L, dims)
-  index_map[matrix(t(coords), ncol = 3)] <- seq_len(v)
-
-  offsets <- expand.grid(dx = -1:1, dy = -1:1, dz = -1:1)
-  offsets <- offsets[!(offsets$dx == 0 & offsets$dy == 0 & offsets$dz == 0), ]
-  if (connectivity == 6) {
-    offsets <- offsets[rowSums(abs(offsets)) == 1, ]
-  } else if (connectivity == 18) {
-    offsets <- offsets[rowSums(abs(offsets)) %in% c(1, 2), ]
-  } else if (connectivity == 26) {
-    offsets <- offsets
-  } else {
-    stop("connectivity must be one of 6, 18, 26")
-  }
-
-  nnz <- 0
-  rows <- integer(0)
-  cols <- integer(0)
-
-  for (i in seq_len(nrow(offsets))) {
-    off <- as.integer(offsets[i, ])
-    nbr_coords <- sweep(coords, 2, off, "+")
-    inside <- nbr_coords[, 1] >= 1 & nbr_coords[, 1] <= dims[1] &
-              nbr_coords[, 2] >= 1 & nbr_coords[, 2] <= dims[2] &
-              nbr_coords[, 3] >= 1 & nbr_coords[, 3] <= dims[3]
-    if (!any(inside)) next
-    nbr_idx <- index_map[matrix(t(nbr_coords[inside, , drop = FALSE]), ncol = 3)]
-    valid <- nbr_idx > 0L
-    if (!any(valid)) next
-    from <- which(inside)[valid]
-    to <- nbr_idx[valid]
-    rows <- c(rows, from)
-    cols <- c(cols, to)
-    nnz <- nnz + length(to)
-  }
-
-  if (nnz == 0) {
-    Adj <- Matrix::sparseMatrix(i = integer(0), j = integer(0), x = numeric(0),
-                                dims = c(v, v))
-  } else {
-    Adj <- Matrix::sparseMatrix(i = c(rows, cols), j = c(cols, rows),
-                                x = 1, dims = c(v, v))
-  }
-  degree <- Matrix::rowSums(Adj)
-  L <- Matrix::Diagonal(x = degree) - Adj
-  list(L = L, degree = as.numeric(degree))
+  build_voxel_laplacian_cpp(volume, as.integer(connectivity))
 }
 
 #' Construct Spatial h-update System Matrix

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -11,6 +11,18 @@ Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
 Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
+// build_voxel_laplacian_cpp
+Rcpp::List build_voxel_laplacian_cpp(Rcpp::NumericVector volume, int connectivity);
+RcppExport SEXP _hrfals_build_voxel_laplacian_cpp(SEXP volumeSEXP, SEXP connectivitySEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::NumericVector >::type volume(volumeSEXP);
+    Rcpp::traits::input_parameter< int >::type connectivity(connectivitySEXP);
+    rcpp_result_gen = Rcpp::wrap(build_voxel_laplacian_cpp(volume, connectivity));
+    return rcpp_result_gen;
+END_RCPP
+}
 // lss_kernel_cpp
 arma::mat lss_kernel_cpp(const arma::mat& C, const arma::mat& A, const arma::mat& Y, const arma::vec& p_vec, double lambda_ridge, bool shared_C, double eig_tol, double denom_tol, arma::uword block_size);
 RcppExport SEXP _hrfals_lss_kernel_cpp(SEXP CSEXP, SEXP ASEXP, SEXP YSEXP, SEXP p_vecSEXP, SEXP lambda_ridgeSEXP, SEXP shared_CSEXP, SEXP eig_tolSEXP, SEXP denom_tolSEXP, SEXP block_sizeSEXP) {
@@ -44,6 +56,7 @@ END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
+    {"_hrfals_build_voxel_laplacian_cpp", (DL_FUNC) &_hrfals_build_voxel_laplacian_cpp, 2},
     {"_hrfals_lss_kernel_cpp", (DL_FUNC) &_hrfals_lss_kernel_cpp, 9},
     {"_hrfals_lss_check_conditioning", (DL_FUNC) &_hrfals_lss_check_conditioning, 2},
     {NULL, NULL, 0}

--- a/src/RcppExports.h
+++ b/src/RcppExports.h
@@ -6,6 +6,8 @@
 #include <RcppArmadillo.h>
 #include <Rcpp.h>
 
-arma::mat lss_kernel_cpp(const arma::mat& C, const arma::mat& A, const arma::mat& Y, double lambda_ridge = 0.0, bool shared_C = true);
+Rcpp::List build_voxel_laplacian_cpp(Rcpp::NumericVector volume, int connectivity = 6);
+arma::mat lss_kernel_cpp(const arma::mat& C, const arma::mat& A, const arma::mat& Y, const arma::vec& p_vec, double lambda_ridge = 0.0, bool shared_C = true, double eig_tol = -1.0, double denom_tol = 1e-10, arma::uword block_size = 1000);
+Rcpp::List lss_check_conditioning(const arma::mat& A, double lambda_ridge = 0.0);
 
 #endif

--- a/src/voxel_laplacian.cpp
+++ b/src/voxel_laplacian.cpp
@@ -1,0 +1,97 @@
+#include <RcppArmadillo.h>
+#include <array>
+// [[Rcpp::depends(RcppArmadillo)]]
+
+using namespace Rcpp;
+
+// [[Rcpp::export]]
+Rcpp::List build_voxel_laplacian_cpp(Rcpp::NumericVector volume, int connectivity = 6) {
+    IntegerVector dims = volume.attr("dim");
+    if(dims.size() != 3) {
+        stop("'volume' must be 3D");
+    }
+    int nx = dims[0], ny = dims[1], nz = dims[2];
+    int total = nx * ny * nz;
+    const double* vol_ptr = volume.begin();
+
+    std::vector<int> xs; xs.reserve(total);
+    std::vector<int> ys; ys.reserve(total);
+    std::vector<int> zs; zs.reserve(total);
+    std::vector<int> index_map(total, 0);
+    int idx = 0;
+    for(int z = 0; z < nz; ++z) {
+        for(int y = 0; y < ny; ++y) {
+            for(int x = 0; x < nx; ++x) {
+                int pos = x + nx * y + nx * ny * z;
+                if(vol_ptr[pos] != 0) {
+                    xs.push_back(x);
+                    ys.push_back(y);
+                    zs.push_back(z);
+                    index_map[pos] = ++idx; // 1-based
+                }
+            }
+        }
+    }
+
+    int v = idx;
+    if(v == 0) {
+        stop("mask contains no voxels");
+    }
+
+    std::vector<std::array<int,3>> offsets;
+    for(int dx = -1; dx <= 1; ++dx) {
+        for(int dy = -1; dy <= 1; ++dy) {
+            for(int dz = -1; dz <= 1; ++dz) {
+                if(dx == 0 && dy == 0 && dz == 0) continue;
+                int sumabs = std::abs(dx) + std::abs(dy) + std::abs(dz);
+                if((connectivity == 6 && sumabs == 1) ||
+                   (connectivity == 18 && (sumabs == 1 || sumabs == 2)) ||
+                   (connectivity == 26)) {
+                    offsets.push_back({{dx, dy, dz}});
+                }
+            }
+        }
+    }
+
+    std::vector<arma::uword> I;
+    std::vector<arma::uword> J;
+    I.reserve(offsets.size() * v);
+    J.reserve(offsets.size() * v);
+
+    for(const auto& off : offsets) {
+        int dx = off[0];
+        int dy = off[1];
+        int dz = off[2];
+        for(int k = 0; k < v; ++k) {
+            int x = xs[k] + dx;
+            int y = ys[k] + dy;
+            int z = zs[k] + dz;
+            if(x < 0 || x >= nx || y < 0 || y >= ny || z < 0 || z >= nz) continue;
+            int pos = x + nx * y + nx * ny * z;
+            int nb = index_map[pos];
+            if(nb > 0 && (k + 1) < nb) {
+                arma::uword from = k;
+                arma::uword to = nb - 1;
+                I.push_back(from);
+                J.push_back(to);
+                I.push_back(to);
+                J.push_back(from);
+            }
+        }
+    }
+
+    arma::sp_mat Adj(v, v);
+    if(!I.empty()) {
+        std::vector<double> val(I.size(), 1.0);
+        Adj = arma::sp_mat(I.begin(), J.begin(), val.begin(), v, v);
+    }
+
+    arma::vec degree = arma::sum(Adj, 1);
+    arma::sp_mat L = -Adj;
+    for(arma::uword i = 0; i < degree.n_elem; ++i) {
+        L(i, i) = degree(i);
+    }
+
+    return Rcpp::List::create(_["L"] = L, _["degree"] = degree);
+}
+


### PR DESCRIPTION
## Summary
- implement voxel Laplacian builder in C++ via Rcpp
- register new routine in RcppExports
- expose helper `build_voxel_laplacian_cpp` in R
- make `build_voxel_laplacian()` call the C++ implementation

## Testing
- `R CMD check` *(fails: command not found)*