### PR TITLE
Add baseline_model support

### DIFF
--- a/R/cfals_wrapper.R
+++ b/R/cfals_wrapper.R
@@ -310,12 +310,15 @@ fmrireg_cfals <- function(fmri_data_obj,
 #' \code{hrfals_fit} object.
 #'
 #' @inheritParams fmrireg_hrf_cfals
+#' @param baseline_model Optional baseline model to project out alongside
+#'   `confound_obj`.
 #' @return An object of class \code{hrfals_fit}.
 #' @export
 hrfals <- function(fmri_data_obj,
                    event_model,
                    hrf_basis,
                    confound_obj = NULL,
+                   baseline_model = NULL,
                    lam_beta = 10,
                    lam_h = 1,
                    lambda_s = 0,
@@ -334,6 +337,7 @@ hrfals <- function(fmri_data_obj,
                      target_event_term_name = target_term,
                      hrf_basis_for_cfals = hrf_basis,
                      confound_obj = confound_obj,
+                     baseline_model = baseline_model,
                      method = "cf_als",
                      lambda_b = lam_beta,
                      lambda_h = lam_h,

--- a/R/estimate_hrf_cfals.R
+++ b/R/estimate_hrf_cfals.R
@@ -9,6 +9,8 @@
 #' @param target_event_term_name Name of the event_term to estimate.
 #' @param hrf_basis_for_cfals An `HRF` object with `nbasis > 1`.
 #' @param confound_obj Optional confound matrix.
+#' @param baseline_model Optional baseline model whose design matrix is
+#'   projected along with `confound_obj`.
 #' @param method Estimation engine to use ("ls_svd_only", "ls_svd_1als", "cf_als").
 #' @param lambda_init Ridge penalty for initial LS solve.
 #' @param lambda_b Ridge penalty for the beta update.
@@ -49,6 +51,7 @@ estimate_hrf_cfals <- function(fmri_data_obj,
                                target_event_term_name,
                                hrf_basis_for_cfals,
                                confound_obj = NULL,
+                               baseline_model = NULL,
                                method = c("ls_svd_1als", "ls_svd_only", "cf_als"),
                                lambda_init = 1,
                                lambda_b = 10,
@@ -72,6 +75,7 @@ estimate_hrf_cfals <- function(fmri_data_obj,
                              fmrireg_event_model,
                              hrf_basis_for_cfals,
                              confound_obj = confound_obj,
+                             baseline_model = baseline_model,
                              hrf_shape_duration_sec = hrf_shape_duration,
                              hrf_shape_sample_res_sec = hrf_shape_resolution)
 

--- a/R/hrfals_design.R
+++ b/R/hrfals_design.R
@@ -13,6 +13,8 @@
 #'   `fmrireg::fmri_dataset`.
 #' @param confound_obj Optional confound matrix with the same number of rows as
 #'   `fmri_data_obj`.
+#' @param baseline_model Optional baseline model whose design matrix is
+#'   projected alongside `confound_obj`.
 #' @param formula Model formula passed to [fmrireg::event_model()]. The default
 #'   expects a column named `condition` in `events`.
 #' @param block Formula specifying the block column. Defaults to `~ block` if a
@@ -23,6 +25,7 @@
 #' @export
 hrfals_design <- function(events, TR, basis, fmri_data_obj,
                           confound_obj = NULL,
+                          baseline_model = NULL,
                           formula = onset ~ hrf(condition),
                           block = if ("block" %in% names(events)) ~ block else NULL,
                           ...) {
@@ -43,5 +46,6 @@ hrfals_design <- function(events, TR, basis, fmri_data_obj,
   create_cfals_design(fmri_data_obj,
                       emod,
                       basis,
-                      confound_obj = confound_obj)
+                      confound_obj = confound_obj,
+                      baseline_model = baseline_model)
 }

--- a/R/hrfals_lss.R
+++ b/R/hrfals_lss.R
@@ -11,6 +11,7 @@
 #'   matching the data used for CF-ALS.
 #' @param confound_obj Optional confound matrix with the same number of
 #'   rows as `fmri_data_obj`.
+#' @param baseline_model Optional baseline model for confound projection.
 #' @param mode Character string specifying the LSS kernel variant.
 #'   If "auto" (default) the function selects "shared" when
 #'   a single HRF is present in `cf_fit$h_coeffs` and "voxel" otherwise.
@@ -23,6 +24,7 @@
 #' @export
 hrfals_lss <- function(cf_fit, events, fmri_data_obj,
                        confound_obj = NULL,
+                       baseline_model = NULL,
                        mode = c("auto", "shared", "voxel"),
                        whitening_matrix = NULL,
                        ...) {
@@ -53,7 +55,8 @@ hrfals_lss <- function(cf_fit, events, fmri_data_obj,
     stop("cf_fit must contain 'fmrireg_hrf_basis_used'")
 
   design <- create_cfals_design(fmri_data_obj, event_model, basis,
-                                confound_obj = confound_obj)
+                                confound_obj = confound_obj,
+                                baseline_model = baseline_model)
   Y <- design$Y_proj
   X_list <- design$X_list_proj
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ cfals_fit <- hrfals(
 print(cfals_fit)
 ```
 
+```r
+# Include a simple baseline model (runwise intercept + linear trend)
+base_mod <- fmrireg::baseline_model(sframe = sframe, degree = 1)
+cfals_baseline <- hrfals(
+  fmri_data_obj = Y_matrix,
+  event_model = emod,
+  hrf_basis = fmrireg::HRF_SPMG3,
+  baseline_model = base_mod,
+  max_alt = 1
+)
+```
+
 ## Main Functions
 
 - `hrfals()`: Main user-facing function for CF-ALS HRF estimation

--- a/tests/testthat/test-baseline_model.R
+++ b/tests/testthat/test-baseline_model.R
@@ -1,0 +1,26 @@
+context("baseline_model handling")
+
+library(fmrireg)
+
+test_that("baseline_model is projected with confounds", {
+  sf <- sampling_frame(10, TR = 1)
+  events <- data.frame(onset = c(2, 7),
+                       condition = factor(c("A", "B")),
+                       block = 1)
+  emod <- event_model(onset ~ hrf(condition), data = events,
+                      block = ~ block, sampling_frame = sf)
+  Y <- matrix(rnorm(20), 10, 2)
+  Z <- matrix(rnorm(10), ncol = 1)
+  bmod <- baseline_model(sframe = sf, degree = 1)
+
+  res1 <- create_cfals_design(Y, emod, HRF_SPMG2,
+                              confound_obj = Z,
+                              baseline_model = bmod)
+  res2 <- create_cfals_design(Y, emod, HRF_SPMG2,
+                              confound_obj = cbind(Z, design_matrix(bmod)))
+
+  expect_equal(res1$Y_proj, res2$Y_proj)
+  for (i in seq_along(res1$X_list_proj)) {
+    expect_equal(res1$X_list_proj[[i]], res2$X_list_proj[[i]])
+  }
+})


### PR DESCRIPTION
## Summary
- support baseline_model confounds in `create_cfals_design`
- pass baseline_model through `hrfals_design`, `hrfals`, `hrfals_lss`, and `estimate_hrf_cfals`
- add README example of baseline_model use
- test baseline_model projection

## Testing
- `R -q -e "devtools::test()"` *(fails: R missing)*