### PR TITLE
Add missing residualization and BLAS tests

### DIFF
--- a/tests/testthat/test-configure_blas.R
+++ b/tests/testthat/test-configure_blas.R
@@ -1,0 +1,12 @@
+context("configure_blas utility")
+
+# configure_blas should invisibly return BLAS library name
+
+lib_info <- withVisible(configure_blas(1))
+expected <- extSoftVersion()["BLAS"]
+
+test_that("configure_blas returns BLAS info invisibly", {
+  expect_true(is.character(lib_info$value))
+  expect_equal(lib_info$value, expected)
+  expect_false(lib_info$visible)
+})

--- a/tests/testthat/test-qr_residualize.R
+++ b/tests/testthat/test-qr_residualize.R
@@ -1,0 +1,25 @@
+context("qr_residualize function")
+
+set.seed(456)
+
+n <- 30
+m <- 6
+Tt <- 8
+A <- matrix(rnorm(n * m), n, m)
+C <- matrix(rnorm(n * Tt), n, Tt)
+
+# reference residualization using base qr.resid
+qr_obj <- qr(A, LAPACK = FALSE)
+ref <- qr.resid(qr_obj, C)
+
+res_default <- qr_residualize(C, A)
+res_lapack <- qr_residualize(C, A, lapack_qr = TRUE)
+
+test_that("qr_residualize matches qr.resid", {
+  expect_equal(res_default, ref, tolerance = 1e-12)
+  expect_equal(dim(res_default), dim(C))
+})
+
+test_that("lapack_qr parameter gives identical result", {
+  expect_equal(res_lapack, ref, tolerance = 1e-12)
+})


### PR DESCRIPTION
## Summary
- add dedicated tests for `qr_residualize`
- test `configure_blas` return value and invisibility

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: R not installed)*