### PR TITLE
Add beta_penalty and design_control parameters

### DIFF
--- a/R/cf_als_engine.R
+++ b/R/cf_als_engine.R
@@ -70,6 +70,10 @@ make_lhs_block_list <- function(XtX_list, XtX_full_list, b_current,
 #' @param max_alt number of alternating updates after initialization
 #' @param epsilon_svd tolerance for singular value screening
 #' @param epsilon_scale tolerance for scale in identifiability step
+#' @param beta_penalty List controlling L1/L2 penalties for the beta-step.
+#'   Currently unused.
+#' @param design_control List of design matrix processing options. Currently
+#'   unused.
 #' @return list with matrices `h` (d x v) and `beta` (k x v). The
 #'   matrix `h` has an attribute `"iterations"` recording the number
 #'   of alternating updates performed.
@@ -93,7 +97,10 @@ cf_als_engine <- function(X_list_proj, Y_proj,
                           h_ref_shape_canonical,
                           max_alt = 1,
                           epsilon_svd = 1e-8,
-                          epsilon_scale = 1e-8) {
+                          epsilon_scale = 1e-8,
+                          beta_penalty = list(l1 = 0, alpha = 1, warm_start = TRUE),
+                          design_control = list(standardize_predictors = TRUE,
+                                                cache_design_blocks = TRUE)) {
 
   # Validate inputs and extract dimensions
   dims <- validate_hrf_engine_inputs(X_list_proj, Y_proj, Phi_recon_matrix, h_ref_shape_canonical)

--- a/R/cfals_wrapper.R
+++ b/R/cfals_wrapper.R
@@ -312,6 +312,10 @@ fmrireg_cfals <- function(fmri_data_obj,
 #' @inheritParams fmrireg_hrf_cfals
 #' @param baseline_model Optional baseline model to project out alongside
 #'   `confound_obj`.
+#' @param beta_penalty List controlling L1/L2 penalties for the beta-step.
+#'   Currently unused.
+#' @param design_control List of design matrix processing options. Currently
+#'   unused.
 #' @return An object of class \code{hrfals_fit}.
 #' @export
 hrfals <- function(fmri_data_obj,
@@ -319,6 +323,9 @@ hrfals <- function(fmri_data_obj,
                    hrf_basis,
                    confound_obj = NULL,
                    baseline_model = NULL,
+                   beta_penalty = list(l1 = 0, alpha = 1, warm_start = TRUE),
+                   design_control = list(standardize_predictors = TRUE,
+                                         cache_design_blocks = TRUE),
                    lam_beta = 10,
                    lam_h = 1,
                    lambda_s = 0,
@@ -349,6 +356,8 @@ hrfals <- function(fmri_data_obj,
                      R_mat = R_mat_param,
                      fullXtX = fullXtX,
                      max_alt = max_alt,
+                     beta_penalty = beta_penalty,
+                     design_control = design_control,
                      ...)
 }
 

--- a/R/estimate_hrf_cfals.R
+++ b/R/estimate_hrf_cfals.R
@@ -42,6 +42,10 @@
 #'   coefficient vector is still estimated per voxel.
 #' @param precompute_xty_flag Logical; passed to `cf_als_engine`.
 #' @param max_alt Number of alternating updates for `cf_als`.
+#' @param beta_penalty List controlling L1/L2 penalties for the beta-step.
+#'   Currently unused.
+#' @param design_control List of design matrix processing options. Currently
+#'   unused.
 #' @param hrf_shape_duration Duration in seconds for reconstructed HRF grid.
 #' @param hrf_shape_resolution Sampling resolution of the HRF grid.
 #' @return An `hrfals_fit` object.
@@ -66,6 +70,9 @@ estimate_hrf_cfals <- function(fmri_data_obj,
                                fullXtX = FALSE,
                                precompute_xty_flag = TRUE,
                                max_alt = 10,
+                               beta_penalty = list(l1 = 0, alpha = 1, warm_start = TRUE),
+                               design_control = list(standardize_predictors = TRUE,
+                                                     cache_design_blocks = TRUE),
                                hrf_shape_duration = attr(hrf_basis_for_cfals, "span"),
                                hrf_shape_resolution = fmrireg_event_model$sampling_frame$TR[1],
                                ...) {
@@ -77,7 +84,8 @@ estimate_hrf_cfals <- function(fmri_data_obj,
                              confound_obj = confound_obj,
                              baseline_model = baseline_model,
                              hrf_shape_duration_sec = hrf_shape_duration,
-                             hrf_shape_sample_res_sec = hrf_shape_resolution)
+                             hrf_shape_sample_res_sec = hrf_shape_resolution,
+                             design_control = design_control)
 
   Xp <- prep$X_list_proj
   Yp <- prep$Y_proj
@@ -130,7 +138,9 @@ estimate_hrf_cfals <- function(fmri_data_obj,
                            precompute_xty_flag = precompute_xty_flag,
                            Phi_recon_matrix = Phi,
                            h_ref_shape_canonical = h_ref_shape_canonical,
-                           max_alt = max_alt)
+                           max_alt = max_alt,
+                           beta_penalty = beta_penalty,
+                           design_control = design_control)
   )
 
   rownames(fit$beta) <- prep$condition_names


### PR DESCRIPTION
## Summary
- add `beta_penalty` and `design_control` arguments to `hrfals` and `estimate_hrf_cfals`
- forward new parameters to `cf_als_engine`
- update `cf_als_engine` signature to accept but not yet use the parameters

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*