### PR TITLE
Update hrfals_fit output

### DIFF
--- a/R/cfals_wrapper.R
+++ b/R/cfals_wrapper.R
@@ -175,10 +175,13 @@ fmrireg_cfals <- function(fmri_data_obj,
                                               k = design$k,
                                               n = n,
                                               v = v,
-                                              fullXtX = fullXtX),
+                                              fullXtX = fullXtX,
+                                              predictor_means = design$predictor_means,
+                                              predictor_sds = design$predictor_sds),
                            residuals = resids,
                            recon_hrf = recon_hrf,
-                           gof = r2)
+                           gof = r2,
+                           beta_penalty = NULL)
   out
 }
 

--- a/R/estimate_hrf_cfals.R
+++ b/R/estimate_hrf_cfals.R
@@ -183,7 +183,8 @@ estimate_hrf_cfals <- function(fmri_data_obj,
              residuals = resids,
              bad_row_idx = prep$bad_row_idx,
              recon_hrf = recon_hrf,
-            gof = r2)
+            gof = r2,
+            beta_penalty = beta_penalty)
 }
 
 #' Spatially-Regularised CF-ALS Convenience Wrapper

--- a/R/hrfals_methods.R
+++ b/R/hrfals_methods.R
@@ -21,11 +21,14 @@ hrfals_fit <- function(h_coeffs, beta_amps, method, lambdas, call,
                        fmrireg_hrf_basis_used, target_event_term_name,
                        phi_recon_matrix, design_info, residuals,
                        bad_row_idx = integer(0),
-                       recon_hrf = NULL, gof = NULL) {
+                       recon_hrf = NULL, gof = NULL,
+                       beta_penalty = NULL) {
+  lambda_list <- as.list(lambdas)
+  lambda_list$beta_penalty <- beta_penalty
   out <- list(h_coeffs = h_coeffs,
               beta_amps = beta_amps,
               method_used = method,
-              lambdas = lambdas,
+              lambdas = lambda_list,
               call = call,
               fmrireg_hrf_basis_used = fmrireg_hrf_basis_used,
               target_event_term_name = target_event_term_name,

--- a/tests/testthat/test-fastlss_fit.R
+++ b/tests/testthat/test-fastlss_fit.R
@@ -4,10 +4,12 @@ make_cfals_fit <- function() {
   h <- matrix(rnorm(2), 1, 2)
   beta <- matrix(rnorm(2), 1, 2)
   phi <- matrix(1, 1, 1)
-  dinfo <- list(d = 1, k = 1, n = 1, v = 2)
+  dinfo <- list(d = 1, k = 1, n = 1, v = 2,
+                predictor_means = 0, predictor_sds = 1)
   hrfals_fit(h, beta, "cf_als", c(beta = 1, h = 1),
              call("hrfals_fit"), fmrireg::HRF_SPMG1, "term", phi, dinfo,
-             matrix(0, 1, 1))
+             matrix(0, 1, 1),
+             beta_penalty = list(l1 = 0.1, alpha = 1, warm_start = TRUE))
 }
 
 test_that("fastlss_fit constructor works", {

--- a/tests/testthat/test-hrfals_fit.R
+++ b/tests/testthat/test-hrfals_fit.R
@@ -4,20 +4,26 @@ test_that("hrfals_fit constructor works", {
   h <- matrix(rnorm(6), 3, 2)
   beta <- matrix(rnorm(4), 2, 2)
   phi <- matrix(rnorm(15), 5, 3)
-  dinfo <- list(d = 3, k = 2, n = 5, v = 2)
+  dinfo <- list(d = 3, k = 2, n = 5, v = 2,
+                predictor_means = c(0, 0), predictor_sds = c(1, 1))
   fit <- hrfals_fit(h, beta, "cf_als", c(beta = 1, h = 1),
-                    quote(test_call()), fmrireg::HRF_SPMG3, "term", phi, dinfo, matrix(0,1,1))
+                    quote(test_call()), fmrireg::HRF_SPMG3, "term", phi, dinfo, matrix(0,1,1),
+                    beta_penalty = list(l1 = 0.1, alpha = 1, warm_start = TRUE))
   expect_s3_class(fit, "hrfals_fit")
   expect_equal(fit$h_coeffs, h)
   expect_equal(fit$beta_amps, beta)
+  expect_equal(fit$lambdas$beta_penalty$l1, 0.1)
+  expect_equal(fit$design_info$predictor_sds, c(1, 1))
 })
 
 test_that("print.hrfals_fit doesn't error", {
   h <- matrix(rnorm(6), 3, 2)
   beta <- matrix(rnorm(4), 2, 2)
   phi <- matrix(rnorm(15), 5, 3)
-  dinfo <- list(d = 3, k = 2, n = 5, v = 2)
+  dinfo <- list(d = 3, k = 2, n = 5, v = 2,
+                predictor_means = c(0, 0), predictor_sds = c(1, 1))
   fit <- hrfals_fit(h, beta, "cf_als", c(beta = 1, h = 1),
-                    quote(test_call()), fmrireg::HRF_SPMG3, "term", phi, dinfo, matrix(0,1,1))
+                    quote(test_call()), fmrireg::HRF_SPMG3, "term", phi, dinfo, matrix(0,1,1),
+                    beta_penalty = list(l1 = 0.1, alpha = 1, warm_start = TRUE))
   expect_output(print(fit), "hrfals Fit")
 })

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -6,10 +6,12 @@ make_hrfals_fit <- function() {
   h <- matrix(rnorm(4), 2, 2)
   beta <- matrix(rnorm(2), 1, 2)
   phi <- diag(2)
-  dinfo <- list(d = 2, k = 1, n = 2, v = 2)
+  dinfo <- list(d = 2, k = 1, n = 2, v = 2,
+                predictor_means = 0, predictor_sds = 1)
   hrfals_fit(h, beta, "cf_als", c(beta = 1, h = 1),
              call("hrfals_fit"), fmrireg::HRF_SPMG1, "term",
-             phi, dinfo, matrix(0, 1, 1))
+             phi, dinfo, matrix(0, 1, 1),
+             beta_penalty = list(l1 = 0.1, alpha = 1, warm_start = TRUE))
 }
 
 


### PR DESCRIPTION
## Summary
- extend `hrfals_fit()` constructor with `beta_penalty`
- persist predictor scaling info when creating fits
- include penalty info in design- and wrapper-based fits
- adjust unit tests for new constructor interface

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`