### PR TITLE
Update docs for sparse beta options

### DIFF
--- a/R/cfals_design_utils_hrfals.R
+++ b/R/cfals_design_utils_hrfals.R
@@ -46,6 +46,9 @@ convolve_timeseries_with_single_basis <- function(raw_timeseries,
 #' @param design_control List with options controlling preprocessing of
 #'   the design matrices. The `standardize_predictors` element indicates
 #'   whether each predictor should be z-scored prior to estimation.
+#'   When `cache_design_blocks = TRUE` the lagged predictor matrices are
+#'   cached in memory if the estimated footprint is below ~32GB; otherwise
+#'   they are generated on the fly with a message to the user.
 #' @return List with projected design matrices, reconstruction info and
 #'   metadata for CFALS engines. Rows of `fmri_data_obj` containing `NA`
 #'   in any voxel are zeroed out along with the corresponding rows in the

--- a/R/cfals_methods.R
+++ b/R/cfals_methods.R
@@ -11,7 +11,9 @@
 #' @param fmrireg_hrf_basis_used HRF basis object supplied to the wrapper.
 #' @param target_event_term_name Name of the event term the HRF was estimated for.
 #' @param phi_recon_matrix The matrix used to reconstruct HRF shape from coefficients.
-#' @param design_info List with design metadata (d, k, n, v, fullXtX).
+#' @param design_info List with design metadata (d, k, n, v, fullXtX) and,
+#'   when predictor standardisation is used, the vectors
+#'   `predictor_means` and `predictor_sds` for rescaling betas.
 #' @param residuals Residual matrix from the projected data fit.
 #' @param bad_row_idx Integer vector of time points that were zeroed due to NA
 #'   values.

--- a/R/cfals_wrapper.R
+++ b/R/cfals_wrapper.R
@@ -19,9 +19,10 @@
 #'   "ls_svd_1als" (default) or "cf_als".
 #' @param lambda_init Ridge penalty for the initial GLM solve used by
 #'   `ls_svd` based methods.
-#' @param lambda_b Ridge penalty for the beta update step. This value
-#'   is ignored when `beta_penalty$l1 > 0` because the Elastic Net
-#'   solver handles all regularisation.
+#' @param lambda_b Ridge penalty for the beta update step. When
+#'   `beta_penalty$l1 > 0` this value is added to the Elastic Net L2
+#'   penalty; otherwise it is the sole L2 regularisation on the beta
+#'   coefficients.
 #' @param lambda_h Ridge penalty for the h update step.
 #' @param lambda_joint Joint ridge penalty applied to both beta and h updates.
 #'   This helps prevent see-saw effects between the two parameter blocks.
@@ -319,9 +320,15 @@ fmrireg_cfals <- function(fmri_data_obj,
 #'   `confound_obj`.
 #' @param beta_penalty List with elements `l1`, `alpha`, and `warm_start`
 #'   forwarded to `estimate_hrf_cfals` for sparse beta estimation.
+#'   Setting `l1 > 0` triggers an Elastic Net beta update with mixing
+#'   parameter `alpha`. Typical `l1` values are between 0.01 and 0.1 for
+#'   scaled predictors. Warm-starting reuses betas from the previous
+#'   iteration to speed convergence.
 #' @param design_control List of design matrix processing options. Set
 #'   `standardize_predictors = TRUE` to z-score continuous predictors
-#'   before estimation.
+#'   before estimation. Betas are returned in the original units. When
+#'   `cache_design_blocks = TRUE` lagged design matrices are cached in
+#'   memory when feasible to avoid recomputation.
 #' @return An object of class \code{hrfals_fit}.
 #' @export
 hrfals <- function(fmri_data_obj,

--- a/R/estimate_hrf_cfals.R
+++ b/R/estimate_hrf_cfals.R
@@ -13,9 +13,9 @@
 #'   projected along with `confound_obj`.
 #' @param method Estimation engine to use ("ls_svd_only", "ls_svd_1als", "cf_als").
 #' @param lambda_init Ridge penalty for initial LS solve.
-#' @param lambda_b Ridge penalty for the beta update. Ignored when
-#'   `beta_penalty$l1 > 0` as the Elastic Net solver controls all
-#'   regularisation.
+#' @param lambda_b Ridge penalty for the beta update. When
+#'   `beta_penalty$l1 > 0` this value adds to the Elastic Net L2
+#'   component, otherwise it is the sole L2 penalty as in classic CF-ALS.
 #' @param lambda_h Ridge penalty for the h update.
 #' @param lambda_joint Joint penalty for the h update.
 #' @param lambda_s Spatial regularization strength controlling the amount of
@@ -45,11 +45,17 @@
 #' @param precompute_xty_flag Logical; passed to `cf_als_engine`.
 #' @param max_alt Number of alternating updates for `cf_als`.
 #' @param beta_penalty List with elements `l1`, `alpha`, and `warm_start`
-#'   passed to `cf_als_engine` for sparse beta estimation. Set `l1 > 0`
-#'   to enable an Elastic Net update.
+#'   controlling sparse beta estimation. Set `l1 > 0` to engage the
+#'   Elastic Net solver with mixing parameter `alpha` in \[0,1\]. Typical
+#'   `l1` values between 0.01 and 0.1 work well for standardised inputs.
+#'   When `warm_start = TRUE` the previous iteration's betas are used as the
+#'   starting point which improves convergence.
 #' @param design_control List of design matrix processing options. Set
 #'   `standardize_predictors = TRUE` to z-score continuous predictors
-#'   before estimation.
+#'   before estimation. Resulting betas are rescaled back to the original
+#'   predictor units. If `cache_design_blocks = TRUE` the time-lagged
+#'   predictor matrices are stored in memory when feasible to accelerate
+#'   repeated HRF updates.
 #' @param hrf_shape_duration Duration in seconds for reconstructed HRF grid.
 #' @param hrf_shape_resolution Sampling resolution of the HRF grid.
 #' @return An `hrfals_fit` object.

--- a/man/create_cfals_design.Rd
+++ b/man/create_cfals_design.Rd
@@ -9,8 +9,11 @@ create_cfals_design(
   event_model,
   hrf_basis,
   confound_obj = NULL,
+  baseline_model = NULL,
   hrf_shape_duration_sec = attr(hrf_basis, "span"),
-  hrf_shape_sample_res_sec = event_model$sampling_frame$TR[1]
+  hrf_shape_sample_res_sec = event_model$sampling_frame$TR[1],
+  design_control = list(standardize_predictors = TRUE,
+    cache_design_blocks = TRUE)
 )
 }
 \arguments{
@@ -22,16 +25,28 @@ create_cfals_design(
 
 \item{confound_obj}{Optional confound matrix.}
 
+\item{baseline_model}{Optional baseline model whose design matrix is
+projected along with \code{confound_obj}.}
+
 \item{hrf_shape_duration_sec}{Duration for the HRF reconstruction grid.}
 
 \item{hrf_shape_sample_res_sec}{Sampling resolution for the HRF grid.}
+
+\item{design_control}{List with options controlling preprocessing of the
+design matrices. When \code{standardize_predictors = TRUE} each
+predictor block is z-scored before estimation and the returned betas are
+rescaled to the original units. If \code{cache_design_blocks = TRUE}
+the lagged predictor matrices are cached in memory when the estimated
+footprint is below \~32GB.}
 }
 \value{
 List with projected design matrices, reconstruction info and
   metadata for CFALS engines. Rows of `fmri_data_obj` containing `NA`
   in any voxel are zeroed out along with the corresponding rows in the
   design matrices and `confound_obj` (if provided). The indices of these
-  rows are returned as `bad_row_idx`.
+  rows are returned as `bad_row_idx`. When predictor standardisation is
+  used the vectors `predictor_means` and `predictor_sds` store the scaling
+  applied to each design block.
 }
 \description{
 This function leverages fmrireg's built-in design matrix creation and

--- a/man/estimate_hrf_cfals.Rd
+++ b/man/estimate_hrf_cfals.Rd
@@ -10,6 +10,7 @@ estimate_hrf_cfals(
   target_event_term_name,
   hrf_basis_for_cfals,
   confound_obj = NULL,
+  baseline_model = NULL,
   method = c("ls_svd_1als", "ls_svd_only", "cf_als"),
   lambda_init = 1,
   lambda_b = 10,
@@ -24,6 +25,9 @@ estimate_hrf_cfals(
   fullXtX = FALSE,
   precompute_xty_flag = TRUE,
   max_alt = 1,
+  beta_penalty = list(l1 = 0, alpha = 1, warm_start = TRUE),
+  design_control = list(standardize_predictors = TRUE,
+    cache_design_blocks = TRUE),
   hrf_shape_duration = attr(hrf_basis_for_cfals, "span"),
   hrf_shape_resolution = fmrireg_event_model$sampling_frame$TR[1],
   ...
@@ -40,11 +44,16 @@ estimate_hrf_cfals(
 
 \item{confound_obj}{Optional confound matrix.}
 
+\item{baseline_model}{Optional baseline model whose design matrix is
+projected alongside \code{confound_obj}.}
+
 \item{method}{Estimation engine to use ("ls_svd_only", "ls_svd_1als", "cf_als").}
 
 \item{lambda_init}{Ridge penalty for initial LS solve.}
 
-\item{lambda_b}{Ridge penalty for the beta update.}
+\item{lambda_b}{Ridge penalty for the beta update. When
+\code{beta_penalty$l1 > 0} this value adds to the Elastic Net L2
+component, otherwise it is the sole L2 penalty.}
 
 \item{lambda_h}{Ridge penalty for the h update.}
 \item{lambda_joint}{Joint penalty for the h update.}
@@ -73,6 +82,16 @@ coefficient vector is still estimated per voxel.}
 \item{precompute_xty_flag}{Logical; passed to `cf_als_engine`.}
 
 \item{max_alt}{Number of alternating updates for `cf_als`.}
+
+\item{beta_penalty}{List with elements \code{l1}, \code{alpha}, and
+\code{warm_start} controlling sparse beta estimation. Typical \code{l1}
+values of 0.01--0.1 are useful for standardised predictors. Setting
+\code{warm_start = TRUE} reuses betas from the previous iteration.}
+
+\item{design_control}{List of design preprocessing options. When
+\code{standardize_predictors = TRUE} predictors are z-scored and the
+returned betas are rescaled. If \code{cache_design_blocks = TRUE} the
+lagged design matrices are cached in memory when possible.}
 
 \item{hrf_shape_duration}{Duration in seconds for reconstructed HRF grid.}
 

--- a/man/hrfals.Rd
+++ b/man/hrfals.Rd
@@ -30,6 +30,10 @@ hrfals(
   event_model,
   hrf_basis,
   confound_obj = NULL,
+  baseline_model = NULL,
+  beta_penalty = list(l1 = 0, alpha = 1, warm_start = TRUE),
+  design_control = list(standardize_predictors = TRUE,
+    cache_design_blocks = TRUE),
   lam_beta = 10,
   lam_h = 1,
   R_mat = NULL,
@@ -56,9 +60,12 @@ points x number of confounds). These nuisance variables are projected
 out from the BOLD data and design matrices prior to CF-ALS estimation.
 Defaults to `NULL` (no confounds).}
 
-\item{lam_beta}{Numeric. The regularization parameter for the beta (amplitude)
-update step. Controls the L2 penalty on the amplitude coefficients.
-Defaults to 10.}
+\item{baseline_model}{Optional baseline model whose design matrix is
+projected alongside \code{confound_obj}.}
+
+\item{lam_beta}{Numeric. L2 penalty strength for the beta update. When
+\code{beta_penalty$l1 > 0} this value is added to the Elastic Net L2
+component; otherwise it is the sole ridge penalty. Defaults to 10.}
 
 \item{lam_h}{Numeric. The regularization parameter for the h (HRF coefficient)
 update step. Controls the L2 penalty on the HRF basis coefficients.
@@ -98,6 +105,18 @@ and h updates. The proposal notes that empirically one alternation
 (`max_alt = 1`) after SVD initialization is often sufficient.
 Defaults to 1.}
 
+\item{beta_penalty}{List with elements \code{l1}, \code{alpha}, and
+\code{warm_start}. Setting \code{l1 > 0} enables an Elastic Net beta
+update with mixing parameter \code{alpha}. Typical \code{l1} values of
+0.01--0.1 work well when predictors are standardised. Warm-starting
+reuses betas from the previous iteration.}
+
+\item{design_control}{List controlling predictor preprocessing. When
+\code{standardize_predictors = TRUE} predictors are z-scored and the
+returned betas are rescaled to the original units. If
+\code{cache_design_blocks = TRUE} lagged design matrices are cached in
+memory when possible.}
+
 \item{...}{Additional arguments passed to the underlying estimation engine.}
 }
 \value{
@@ -109,7 +128,7 @@ An object of class `fmrireg_cfals_fit`. This object contains:
     \item `residuals`: An n x v matrix of model residuals after fitting (n = number of timepoints).
     \item `hrf_basis_used`: The `hrf_basis` object that was supplied to the function.
     \item `lambdas_used`: A named list or vector containing the regularization parameters (`lam_beta`, `lam_h`) used in the estimation.
-    \item `design_info`: A list containing dimensions and flags used during estimation (e.g., d, k, n, v, `fullXtX`).
+    \item `design_info`: A list containing dimensions and flags used during estimation (e.g., d, k, n, v, `fullXtX`) and, when predictor standardisation is used, the vectors `predictor_means` and `predictor_sds`.
     \item `gof_per_voxel`: Optional. Goodness-of-fit statistics per voxel, such as R-squared.
     \item (Other elements as defined by the `fmrireg_cfals_fit` class structure from the proposal, like `call`).
   }

--- a/man/hrfals_fit.Rd
+++ b/man/hrfals_fit.Rd
@@ -33,7 +33,9 @@ hrfals_fit(
 
 \item{fmrireg_hrf_basis_used}{HRF basis object supplied to the wrapper.}
 
-\item{design_info}{List with design metadata (d, k, n, v, fullXtX).}
+\item{design_info}{List with design metadata (d, k, n, v, fullXtX). When
+predictor standardisation is used the vectors `predictor_means` and
+`predictor_sds` are also included.}
 
 \item{residuals}{Residual matrix from the projected data fit.}
 


### PR DESCRIPTION
## Summary
- document new sparse CF-ALS options
- explain predictor standardization and caching
- document design info fields

## Testing
- `git status --short`