### PR TITLE
Add stress test and example vignette

### DIFF
--- a/tests/testthat/test-sparse_cfals_stress.R
+++ b/tests/testthat/test-sparse_cfals_stress.R
@@ -1,0 +1,59 @@
+context("sparse CFALS stress test")
+
+# helper function to simulate large data set
+simulate_large_predictor_data <- function(n = 500, d = 20, k = 500,
+                                          n_active = 10, noise_sd = 0.05) {
+  set.seed(123)
+  h_true <- rnorm(d)
+  beta_true <- c(rep(1, n_active), rep(0, k - n_active))
+  X_list <- lapply(seq_len(k), function(i) matrix(rnorm(n * d), n, d))
+  Y <- matrix(0, n, 1)
+  for (c in seq_len(k)) {
+    Y <- Y + (X_list[[c]] %*% h_true) * beta_true[c]
+  }
+  Y <- Y + matrix(rnorm(n, sd = noise_sd), n, 1)
+  list(X_list = X_list, Y = Y, d = d, k = k)
+}
+
+
+test_that("cf_als_engine handles many predictors with caching options", {
+  skip_on_cran()
+  dat <- simulate_large_predictor_data()
+
+  res_cache <- cf_als_engine(
+    dat$X_list, dat$Y,
+    lambda_b = 0.1,
+    lambda_h = 0.1,
+    lambda_init = 0.1,
+    R_mat_eff = diag(dat$d),
+    fullXtX_flag = FALSE,
+    precompute_xty_flag = TRUE,
+    Phi_recon_matrix = diag(dat$d),
+    h_ref_shape_canonical = rep(1, dat$d),
+    max_alt = 1,
+    beta_penalty = list(l1 = 0.05, alpha = 1, warm_start = TRUE),
+    design_control = list(standardize_predictors = FALSE,
+                          cache_design_blocks = TRUE)
+  )
+
+  res_nocache <- cf_als_engine(
+    dat$X_list, dat$Y,
+    lambda_b = 0.1,
+    lambda_h = 0.1,
+    lambda_init = 0.1,
+    R_mat_eff = diag(dat$d),
+    fullXtX_flag = FALSE,
+    precompute_xty_flag = TRUE,
+    Phi_recon_matrix = diag(dat$d),
+    h_ref_shape_canonical = rep(1, dat$d),
+    max_alt = 1,
+    beta_penalty = list(l1 = 0.05, alpha = 1, warm_start = TRUE),
+    design_control = list(standardize_predictors = FALSE,
+                          cache_design_blocks = FALSE)
+  )
+
+  expect_equal(dim(res_cache$beta), c(dat$k, 1))
+  expect_equal(dim(res_nocache$beta), c(dat$k, 1))
+  expect_equal(dim(res_cache$h), c(dat$d, 1))
+  expect_equal(dim(res_nocache$h), c(dat$d, 1))
+})

--- a/vignettes/many_continuous_predictors.Rmd
+++ b/vignettes/many_continuous_predictors.Rmd
@@ -1,0 +1,72 @@
+---
+title: "Estimating Shared HRFs with Many Continuous Predictors"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Many Continuous Predictors}
+  %\VignetteEngine{rmarkdown::html_vignette}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+```
+
+This vignette demonstrates the sparse CF-ALS implementation for scenarios
+with a large number of continuous predictors.  The helper function
+`hrfals_sparse()` provides sensible defaults for these use cases.
+
+## Simulated example
+
+The code below simulates a small data set with many predictors and then
+fits the model using `hrfals_sparse()`.  The same workflow applies when
+using real fMRI data and a design created with `fmrireg::event_model()`.
+
+```{r eval=FALSE}
+library(hrfals)
+library(fmrireg)
+
+n  <- 60   # time points
+k  <- 100  # number of continuous predictors
+h_len <- 5 # length of FIR basis
+
+# simulate predictors
+X_list <- lapply(seq_len(k), function(i) matrix(rnorm(n * h_len), n, h_len))
+
+# sparse beta pattern
+beta_true <- c(rep(1, 5), rep(0, k - 5))
+
+# true HRF coefficients
+h_true <- rnorm(h_len)
+
+# generate BOLD signal
+Y <- matrix(0, n, 1)
+for (i in seq_len(k)) {
+  Y <- Y + (X_list[[i]] %*% h_true) * beta_true[i]
+}
+Y <- Y + matrix(rnorm(n, sd = 0.1), n, 1)
+
+# fit using sparse CF-ALS
+fit <- cf_als_engine(
+  X_list, Y,
+  lambda_b = 0.1,
+  lambda_h = 0.1,
+  lambda_init = 0.1,
+  R_mat_eff = diag(h_len),
+  fullXtX_flag = FALSE,
+  precompute_xty_flag = TRUE,
+  Phi_recon_matrix = diag(h_len),
+  h_ref_shape_canonical = rep(1, h_len),
+  max_alt = 2,
+  beta_penalty = list(l1 = 0.05, alpha = 1, warm_start = TRUE),
+  design_control = list(standardize_predictors = TRUE,
+                        cache_design_blocks = TRUE)
+)
+
+plot(fit)
+```
+
+The estimated HRF and sparse beta weights can be inspected from the
+returned `fit` object.  When working with real fMRI data you would
+construct `X_list` via `create_cfals_design()` which supports
+splitting a single `Ident` term into multiple predictor blocks.
+


### PR DESCRIPTION
## Summary
- add a stress test exercising CF-ALS with 500 predictors
- provide a vignette showing how to use sparse CF-ALS with many continuous predictors

## Testing
- `git status --short`
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`