### PR TITLE
Add tests for normalization, prediction, and tuning

### DIFF
--- a/tests/testthat/test-normalize_and_predict.R
+++ b/tests/testthat/test-normalize_and_predict.R
@@ -1,0 +1,36 @@
+context("normalize_and_align_hrf and predict")
+
+library(fmrireg)
+
+# Test sign flipping and zeroing in normalize_and_align_hrf
+
+test_that("normalize_and_align_hrf flips sign and zeroes small scale", {
+  H <- matrix(c(-0.5, -1, -1e-8, 1e-8), 2, 2)
+  B <- matrix(c(2, 3), 1, 2)
+  Phi <- diag(2)
+  href <- c(1, 1)
+  Yp <- matrix(0, 2, 2)
+  X_list <- list(cond1 = matrix(0, 2, 2))
+  res <- normalize_and_align_hrf(H, B, Phi, href, epsilon_scale = 1e-6,
+                                 Y_proj = Yp, X_list_proj = X_list)
+  expect_equal(res$h[, 1], c(0.5, 1))
+  expect_equal(res$beta[1, 1], -2)
+  expect_true(all(res$h[, 2] == 0))
+  expect_true(all(res$beta[, 2] == 0))
+})
+
+# Test behaviour of predict.hrfals_fit
+
+test_that("predict.hrfals_fit returns negative residuals", {
+  h <- matrix(rnorm(4), 2, 2)
+  beta <- matrix(rnorm(2), 1, 2)
+  phi <- diag(2)
+  dinfo <- list(d = 2, k = 1, n = 1, v = 2,
+                predictor_means = 0, predictor_sds = 1)
+  resids <- matrix(c(0.1, -0.2), 1, 2)
+  fit <- hrfals_fit(h, beta, "cf_als", c(beta = 1, h = 1),
+                    call("hrfals_fit"), fmrireg::HRF_SPMG1, "term",
+                    phi, dinfo, resids)
+  expect_warning(pred <- predict(fit), "Fitted values computation")
+  expect_equal(pred, -resids)
+})

--- a/tests/testthat/test-tune_beta_l1_hrfals.R
+++ b/tests/testthat/test-tune_beta_l1_hrfals.R
@@ -1,0 +1,41 @@
+context("tune_beta_l1_hrfals")
+
+library(fmrireg)
+
+simulate_small_data <- function() {
+  sf <- sampling_frame(blocklens = 20, TR = 1)
+  events <- data.frame(onset = c(5, 15), condition = factor(c("A", "B")), block = 1)
+  emod <- event_model(onset ~ hrf(condition), data = events,
+                      block = ~ block, sampling_frame = sf)
+  design <- create_fmri_design(emod, HRF_SPMG3)
+  X_list <- design$X_list
+  d <- design$d
+  k <- design$k
+  v <- 2
+  n_timepoints <- length(samples(sf, global = TRUE))
+  h_true <- matrix(rnorm(d * v), d, v) * 0.5
+  beta_true <- matrix(rnorm(k * v), k, v) * 0.5
+  Y <- matrix(0, n_timepoints, v)
+  for (c in seq_along(X_list)) {
+    Y <- Y + (X_list[[c]] %*% h_true) *
+      matrix(rep(beta_true[c, ], each = nrow(Y)), nrow(Y), v)
+  }
+  Y <- Y + matrix(rnorm(length(Y), sd = 0.05), nrow(Y), v)
+  attr(Y, "sampling_frame") <- sf
+  list(Y = Y, emod = emod)
+}
+
+
+test_that("tune_beta_l1_hrfals selects best penalty", {
+  dat <- simulate_small_data()
+  res <- tune_beta_l1_hrfals(dat$Y, dat$emod, HRF_SPMG3,
+                             l1_grid = c(0, 0.01),
+                             n_outer_iterations_cfals = 1,
+                             other_hrfals_args = list(lam_beta = 0.1,
+                                                       lam_h = 0.1,
+                                                       max_alt = 1),
+                             seed = 123)
+  expect_s3_class(res, "data.frame")
+  expect_equal(attr(res, "best_l1"), res$l1[which.min(res$test_mse)])
+  expect_true(res$best[which.min(res$test_mse)])
+})


### PR DESCRIPTION
## Summary
- add tests for normalization helper and predict method
- add unit test for L1 tuning helper

## Testing
- `Rscript` (failed: command not found)

------
https://chatgpt.com/codex/tasks/task_e_6846e606a76c832d8376e4d137f168dc